### PR TITLE
Make MethodReturn public to easily allow modifying return values

### DIFF
--- a/src/Avatar/IMethodReturn.cs
+++ b/src/Avatar/IMethodReturn.cs
@@ -15,7 +15,7 @@ namespace Avatars
 
         /// <summary>
         /// Optional exception if the method invocation results in 
-        /// an exception being thrown.
+        /// an exception being thrown. <see langword="null"/> otherwise.
         /// </summary>
         Exception? Exception { get; }
 
@@ -26,7 +26,8 @@ namespace Avatars
 
         /// <summary>
         /// The value being returned for a non-void method if no exception 
-        /// was thrown.
+        /// was thrown. <see langword="null"/> for void method or whenever 
+        /// <see cref="Exception"/> is non-<see langword="null"/>.
         /// </summary>
         object? ReturnValue { get; }
     }

--- a/src/Avatar/IsExternalInit.cs
+++ b/src/Avatar/IsExternalInit.cs
@@ -1,0 +1,17 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.ComponentModel;
+
+namespace System.Runtime.CompilerServices
+{
+    /// <summary>
+    /// Reserved to be used by the compiler for tracking metadata.
+    /// This class should not be used by developers in source code.
+    /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    sealed class IsExternalInit
+    {
+    }
+}

--- a/src/Avatar/MethodInvocation.cs
+++ b/src/Avatar/MethodInvocation.cs
@@ -18,6 +18,16 @@ namespace Avatars
         readonly ExecuteDelegate callBase;
 
         /// <summary>
+        /// Initializes the <see cref="MethodInvocation"/> for a method that has no parameters.
+        /// </summary>
+        /// <param name="target">The target object where the invocation is being performed.</param>
+        /// <param name="method">The method being invoked.</param>
+        public MethodInvocation(object target, MethodBase method)
+            : this(target, method, default(IArgumentCollection))
+        {
+        }
+
+        /// <summary>
         /// Initializes the <see cref="MethodInvocation"/> with the given parameters.
         /// </summary>
         /// <param name="target">The target object where the invocation is being performed.</param>

--- a/src/Avatar/MethodReturn.cs
+++ b/src/Avatar/MethodReturn.cs
@@ -8,85 +8,97 @@ using System.Text;
 namespace Avatars
 {
     /// <summary>
-    /// Default implementation of <see cref="IMethodReturn"/>.
+    /// Represents the returned value(s) or exception from a method 
+    /// invocation.
     /// </summary>
-    class MethodReturn : IMethodReturn
+    public record MethodReturn : IMethodReturn
     {
         readonly IMethodInvocation invocation;
 
-        public MethodReturn(IMethodInvocation invocation, object? returnValue, IArgumentCollection arguments)
-        {
-            if (invocation.MethodBase.GetParameters().Length != arguments.Count)
-                throw new ArgumentException(ThisAssembly.Strings.MethodArgumentsMismatch(invocation.MethodBase.Name, invocation.MethodBase.GetParameters().Length, arguments.Count), nameof(arguments));
+    /// <summary>
+    /// Initializes a value returning call.
+    /// </summary>
+    /// <param name="invocation">The invocation that generated the return.</param>
+    /// <param name="returnValue">Optional return value for non-void methods.</param>
+    /// <param name="arguments">All arguments of the invocation, including ref/out ones.</param>
+    public MethodReturn(IMethodInvocation invocation, object? returnValue, IArgumentCollection arguments)
+    {
+        if (invocation.MethodBase.GetParameters().Length != arguments.Count)
+            throw new ArgumentException(ThisAssembly.Strings.MethodArgumentsMismatch(invocation.MethodBase.Name, invocation.MethodBase.GetParameters().Length, arguments.Count), nameof(arguments));
 
-            this.invocation = invocation;
+        this.invocation = invocation;
 
-            ReturnValue = returnValue;
-            Outputs = GetOutputs(arguments);
-        }
-
-        public MethodReturn(IMethodInvocation invocation, Exception exception)
-        {
-            this.invocation = invocation;
-            Outputs = GetOutputs(invocation.Arguments);
-            Exception = exception;
-        }
-
-        /// <summary>
-        /// The collection of output parameters. If the method has no output
-        /// parameters, this is a zero-length list (never null).
-        /// </summary>
-        public IArgumentCollection Outputs { get; }
-
-        public object? ReturnValue { get; }
-
-        public Exception? Exception { get; }
-
-        public IDictionary<string, object> Context => invocation.Context;
-
-        /// <summary>
-        /// Gets a friendly representation of the object.
-        /// </summary>
-        /// <devdoc>
-        /// We don't want to optimize code coverage for this since it's a debugger aid only. 
-        /// Annotating this method with DebuggerNonUserCode achieves that.
-        /// No actual behavior depends on these strings.
-        /// </devdoc>
-        [ExcludeFromCodeCoverage]
-#if !DEBUG
-        [DebuggerNonUserCode]
-#endif
-        public override string ToString()
-        {
-            var result = new StringBuilder();
-            result.Append(invocation.ToString());
-
-            if (Exception != null)
-            {
-                result.Append($" => throw new {Exception.GetType().Name}(\"{Exception.Message}\")");
-            }
-            else if (invocation.MethodBase is MethodInfo r && r.ReturnType != typeof(void))
-            {
-                result.Append(" => ")
-                    .Append(
-                        ReturnValue == null ? "null" :
-                        r.ReturnType == typeof(string) ? $"\"{ReturnValue}\"" :
-                        r.ReturnType == typeof(bool) ? ReturnValue.ToString().ToLowerInvariant() :
-                        ReturnValue);
-            }
-
-            return result.ToString();
-        }
-
-        IArgumentCollection GetOutputs(IArgumentCollection arguments)
-        {
-            var outputs = new ArgumentCollection(invocation.MethodBase.GetParameters()
-                .Where(x => x.ParameterType.IsByRef).ToArray());
-
-            foreach (var info in outputs)
-                outputs.Add(info.Name, arguments.GetValue(info.Name));
-
-            return outputs;
-        }
+        ReturnValue = returnValue;
+        Outputs = GetOutputs(arguments);
     }
+
+    /// <summary>
+    /// Initializes a return that represents a thrown exception from the invocation.
+    /// </summary>
+    /// <param name="invocation">The invocation that generated the return.</param>
+    /// <param name="exception">The exception resulting from the invocation.</param>
+    public MethodReturn(IMethodInvocation invocation, Exception exception)
+    {
+        this.invocation = invocation;
+        Outputs = GetOutputs(invocation.Arguments);
+        Exception = exception;
+    }
+
+    /// <inheritdoc />
+    public IArgumentCollection Outputs { get; init; }
+
+    /// <inheritdoc />
+    public object? ReturnValue { get; init; }
+
+    /// <inheritdoc />
+    public Exception? Exception { get; init; }
+
+    /// <inheritdoc />
+    public IDictionary<string, object> Context => invocation.Context;
+
+    /// <summary>
+    /// Gets a friendly representation of the object.
+    /// </summary>
+    /// <devdoc>
+    /// We don't want to optimize code coverage for this since it's a debugger aid only. 
+    /// Annotating this method with DebuggerNonUserCode achieves that.
+    /// No actual behavior depends on these strings.
+    /// </devdoc>
+    [ExcludeFromCodeCoverage]
+#if !DEBUG
+    [DebuggerNonUserCode]
+#endif
+    public override string ToString()
+    {
+        var result = new StringBuilder();
+        result.Append(invocation.ToString());
+
+        if (Exception != null)
+        {
+            result.Append($" => throw new {Exception.GetType().Name}(\"{Exception.Message}\")");
+        }
+        else if (invocation.MethodBase is MethodInfo r && r.ReturnType != typeof(void))
+        {
+            result.Append(" => ")
+                .Append(
+                    ReturnValue == null ? "null" :
+                    r.ReturnType == typeof(string) ? $"\"{ReturnValue}\"" :
+                    r.ReturnType == typeof(bool) ? ReturnValue.ToString().ToLowerInvariant() :
+                    ReturnValue);
+        }
+
+        return result.ToString();
+    }
+
+    IArgumentCollection GetOutputs(IArgumentCollection arguments)
+    {
+        var outputs = new ArgumentCollection(invocation.MethodBase.GetParameters()
+            .Where(x => x.ParameterType.IsByRef).ToArray());
+
+        foreach (var info in outputs)
+            outputs.Add(info.Name, arguments.GetValue(info.Name));
+
+        return outputs;
+    }
+}
 }


### PR DESCRIPTION
Otherwise extenders would need to implement the (mostly trivial) class themselves, which doesn't add value and is just friction. All our other interfaces have public implementations anyway.

We make the class a record too, so it can easily be modified on the fly with `result with { Exception = ..., ReturnValue = ... }`, for example.

Fixes #61.