### PR TITLE
Make arguments first-class and strong-typed

### DIFF
--- a/samples/Samples/TargetInvocation/DynamicTargetBehavior.cs
+++ b/samples/Samples/TargetInvocation/DynamicTargetBehavior.cs
@@ -66,11 +66,11 @@ namespace Samples.TargetInvocation
 
                 return invocation =>
                 {
-                    var args = invocation.Arguments.Select((p, i) => invocation.Arguments.GetValue(i)).ToArray();
+                    var args = invocation.Arguments.Select(x => x.RawValue).ToArray();
                     try
                     {
                         target.DynamicInvoke(new[] { site, this.target }.Concat(args).ToArray());
-                        return invocation.CreateValueReturn(null, args);
+                        return invocation.CreateReturn();
                     }
                     catch (TargetInvocationException tie)
                     {
@@ -94,11 +94,11 @@ namespace Samples.TargetInvocation
 
                 return invocation =>
                 {
-                    var args = invocation.Arguments.Select((p, i) => invocation.Arguments.GetValue(i)).ToArray();
+                    var args = invocation.Arguments.Select(x => x.RawValue).ToArray();
                     try
                     {
                         var result = target.DynamicInvoke(new[] { site, this.target }.Concat(args).ToArray());
-                        return invocation.CreateValueReturn(result, args);
+                        return invocation.CreateValueReturn(result);
                     }
                     catch (TargetInvocationException tie)
                     {

--- a/src/Avatar.DynamicProxy/DynamicAvatarFactory.cs
+++ b/src/Avatar.DynamicProxy/DynamicAvatarFactory.cs
@@ -19,10 +19,7 @@ namespace Avatars
 
         static DynamicAvatarFactory()
         {
-#pragma warning disable 618
             AttributesToAvoidReplicating.Add<SecurityPermissionAttribute>();
-#pragma warning restore 618
-
             AttributesToAvoidReplicating.Add<System.Runtime.InteropServices.MarshalAsAttribute>();
             AttributesToAvoidReplicating.Add<System.Runtime.InteropServices.TypeIdentifierAttribute>();
 

--- a/src/Avatar.UnitTests/.Scenarios.cs
+++ b/src/Avatar.UnitTests/.Scenarios.cs
@@ -28,7 +28,7 @@ namespace Avatars.UnitTests
         };
 
         // Run particular scenarios using the TD.NET ad-hoc runner.
-        public void RunScenario() => new Scenarios().Run(ThisAssembly.Constants.Scenarios.ClassBaseType);
+        public void RunScenario() => new Scenarios().Run(ThisAssembly.Constants.Scenarios.ClassBaseAbstractType);
 
         [Theory]
         [MemberData(nameof(GetScenarios))]

--- a/src/Avatar.UnitTests/ArgumentCollectionTests.cs
+++ b/src/Avatar.UnitTests/ArgumentCollectionTests.cs
@@ -14,36 +14,36 @@ namespace Avatars.UnitTests
 
         [Fact]
         public void ThrowsIfMismatchValuesLength()
-            => Assert.Throws<ArgumentException>(() => new ArgumentCollection(valueTypeMethod.GetParameters(), 5, "Foo"));
+            => Assert.Throws<TargetParameterCountException>(() => ArgumentCollection.Create(valueTypeMethod.GetParameters(), 5, "Foo"));
 
         [Fact]
-        public void ThrowsIfParameterNameNotFound()
-            => Assert.Throws<KeyNotFoundException>(() => new ArgumentCollection(valueTypeMethod.GetParameters(), 5)["foo"]);
+        public void ThrowsIfNameNotFound()
+            => Assert.Throws<KeyNotFoundException>(() => ArgumentCollection.Create(valueTypeMethod.GetParameters(), 5)["foo"]);
 
         [Fact]
-        public void ThrowsIfParameterIndexNotFound()
-            => Assert.Throws<IndexOutOfRangeException>(() => new ArgumentCollection(valueTypeMethod.GetParameters(), 5)[42]);
+        public void ThrowsIfIndexNotFound()
+            => Assert.Throws<IndexOutOfRangeException>(() => ArgumentCollection.Create(valueTypeMethod.GetParameters(), 5)[42]);
 
         [Fact]
         public void ThrowsIfGetValueNameNotFound()
-            => Assert.Throws<KeyNotFoundException>(() => new ArgumentCollection(valueTypeMethod.GetParameters(), 5).GetValue("foo"));
+            => Assert.Throws<KeyNotFoundException>(() => ArgumentCollection.Create(valueTypeMethod.GetParameters(), 5).GetValue("foo"));
 
         [Fact]
         public void ThrowsIfGetValueIndexNotFound()
-            => Assert.Throws<IndexOutOfRangeException>(() => new ArgumentCollection(valueTypeMethod.GetParameters(), 5).GetValue(42));
+            => Assert.Throws<IndexOutOfRangeException>(() => ArgumentCollection.Create(valueTypeMethod.GetParameters(), 5).GetValue(42));
 
         [Fact]
         public void ThrowsIfSetValueNameNotFound()
-            => Assert.Throws<KeyNotFoundException>(() => new ArgumentCollection(valueTypeMethod.GetParameters(), 5).SetValue("foo", 42));
+            => Assert.Throws<KeyNotFoundException>(() => ArgumentCollection.Create(valueTypeMethod.GetParameters(), 5).SetValue("foo", 42));
 
         [Fact]
         public void ThrowsIfSetValueIndexNotFound()
-            => Assert.Throws<IndexOutOfRangeException>(() => new ArgumentCollection(valueTypeMethod.GetParameters(), 5).SetValue(42, 42));
+            => Assert.Throws<IndexOutOfRangeException>(() => ArgumentCollection.Create(valueTypeMethod.GetParameters(), 5).SetValue(42, 42));
 
         [Fact]
         public void AccessValueByIndex()
         {
-            var arguments = new ArgumentCollection(valueTypeMethod.GetParameters(), 5);
+            var arguments = ArgumentCollection.Create(valueTypeMethod.GetParameters(), 5);
 
             Assert.Equal(5, arguments.GetValue(0));
         }
@@ -51,7 +51,7 @@ namespace Avatars.UnitTests
         [Fact]
         public void AccessValueByName()
         {
-            var arguments = new ArgumentCollection(valueTypeMethod.GetParameters(), 5);
+            var arguments = ArgumentCollection.Create(valueTypeMethod.GetParameters(), 5);
 
             Assert.Equal(5, arguments.GetValue("value"));
 
@@ -61,77 +61,58 @@ namespace Avatars.UnitTests
         }
 
         [Fact]
-        public void GetInfoFromIndex()
-            => Assert.NotNull(new ArgumentCollection(valueTypeMethod.GetParameters())[0]);
-
-        [Fact]
-        public void GetInfoFromName()
-            => Assert.NotNull(new ArgumentCollection(valueTypeMethod.GetParameters())["value"]);
-
-        [Fact]
         public void Count()
 #pragma warning disable xUnit2013 // Do not use equality check to check for collection size.
-            => Assert.Equal(1, new ArgumentCollection(valueTypeMethod.GetParameters()).Count);
+            => Assert.Equal(1, ArgumentCollection.Create(valueTypeMethod.GetParameters(), 5).Count);
 #pragma warning restore xUnit2013 // Do not use equality check to check for collection size.
-
 
         [Fact]
         public void GetTyped()
         {
-            Assert.Equal(5, new ArgumentCollection(valueTypeMethod.GetParameters(), 5).Get<int>(0));
-            Assert.Equal(5, new ArgumentCollection(valueTypeMethod.GetParameters(), 5).Get<int>("value"));
+            Assert.Equal(5, ArgumentCollection.Create(valueTypeMethod.GetParameters(), 5).Get<int>(0));
+            Assert.Equal(5, ArgumentCollection.Create(valueTypeMethod.GetParameters(), 5).Get<int>("value"));
 
             // If nullable annotations are ignored and we request a nullable int, it should still work.
 #nullable disable
-            Assert.Equal((int?)null, new ArgumentCollection(nullableValueTypeMethod.GetParameters(), new object[] { null }).Get<int?>(0));
-            Assert.Equal((int?)null, new ArgumentCollection(nullableValueTypeMethod.GetParameters(), new object[] { null }).Get<int?>("value"));
+            Assert.Equal((int?)null, ArgumentCollection.Create(nullableValueTypeMethod.GetParameters(), default(int?)).Get<int?>(0));
+            Assert.Equal((int?)null, ArgumentCollection.Create(nullableValueTypeMethod.GetParameters(), default(int?)).Get<int?>("value"));
 #nullable restore
 
-            Assert.Equal("foo", new ArgumentCollection(referenceTypeMethod.GetParameters(), "foo").Get<string>(0));
-            Assert.Equal("foo", new ArgumentCollection(referenceTypeMethod.GetParameters(), "foo").Get<string>("value"));
+            Assert.Equal("foo", ArgumentCollection.Create(referenceTypeMethod.GetParameters(), "foo").Get<string>(0));
+            Assert.Equal("foo", ArgumentCollection.Create(referenceTypeMethod.GetParameters(), "foo").Get<string>("value"));
         }
 
         [Fact]
         public void GetOptionalTyped()
         {
-            Assert.Equal(5, new ArgumentCollection(valueTypeMethod.GetParameters(), 5).GetNullable<int>(0));
-            Assert.Equal(5, new ArgumentCollection(valueTypeMethod.GetParameters(), 5).GetNullable<int>("value"));
+            Assert.Equal(5, ArgumentCollection.Create(valueTypeMethod.GetParameters(), 5).GetNullable<int>(0));
+            Assert.Equal(5, ArgumentCollection.Create(valueTypeMethod.GetParameters(), 5).GetNullable<int>("value"));
 
-            Assert.Equal((int?)null, new ArgumentCollection(nullableValueTypeMethod.GetParameters(), new object[] { null }).GetNullable<int?>(0));
-            Assert.Equal((int?)null, new ArgumentCollection(nullableValueTypeMethod.GetParameters(), new object[] { null }).GetNullable<int?>("value"));
+            Assert.Equal((int?)null, ArgumentCollection.Create<int?>(nullableValueTypeMethod.GetParameters(), null).GetNullable<int?>(0));
+            Assert.Equal((int?)null, ArgumentCollection.Create<int?>(nullableValueTypeMethod.GetParameters(), null).GetNullable<int?>("value"));
 
-            Assert.Equal("foo", new ArgumentCollection(referenceTypeMethod.GetParameters(), "foo").GetNullable<string>(0));
-            Assert.Equal("foo", new ArgumentCollection(referenceTypeMethod.GetParameters(), "foo").GetNullable<string>("value"));
+            Assert.Equal("foo", ArgumentCollection.Create(referenceTypeMethod.GetParameters(), "foo").GetNullable<string>(0));
+            Assert.Equal("foo", ArgumentCollection.Create(referenceTypeMethod.GetParameters(), "foo").GetNullable<string>("value"));
 
-            Assert.Null(new ArgumentCollection(referenceTypeMethod.GetParameters(), new object[] { null }).GetNullable<string>(0));
-            Assert.Null(new ArgumentCollection(referenceTypeMethod.GetParameters(), new object[] { null }).GetNullable<string>("value"));
-        }
-
-        [Fact]
-        public void GetOptionalTypedWithNoValue()
-        {
-            Assert.Equal((int?)null, new ArgumentCollection(nullableValueTypeMethod.GetParameters()).GetNullable<int?>(0));
-            Assert.Equal((int?)null, new ArgumentCollection(nullableValueTypeMethod.GetParameters()).GetNullable<int?>("value"));
-
-            Assert.Null(new ArgumentCollection(referenceTypeMethod.GetParameters()).GetNullable<string>(0));
-            Assert.Null(new ArgumentCollection(referenceTypeMethod.GetParameters()).GetNullable<string>("value"));
+            Assert.Null(ArgumentCollection.Create<string>(referenceTypeMethod.GetParameters(), null).GetNullable<string>(0));
+            Assert.Null(ArgumentCollection.Create<string>(referenceTypeMethod.GetParameters(), null).GetNullable<string>("value"));
         }
 
         [Fact]
         public void GetTypedThrowsIfNull()
         {
-            Assert.Throws<ArgumentNullException>(() => new ArgumentCollection(valueTypeMethod.GetParameters(), new object[] { null }).Get<int>(0));
-            Assert.Throws<ArgumentNullException>(() => new ArgumentCollection(valueTypeMethod.GetParameters(), new object[] { null }).Get<int>("value"));
+            Assert.Throws<ArgumentNullException>(() => new ArgumentCollection(new ObjectArgument(valueTypeMethod.GetParameters()[0], null)).Get<int>(0));
+            Assert.Throws<ArgumentNullException>(() => new ArgumentCollection(new ObjectArgument(valueTypeMethod.GetParameters()[0], null)).Get<int>("value"));
 
-            Assert.Throws<ArgumentNullException>(() => new ArgumentCollection(valueTypeMethod.GetParameters(), new object[] { null }).Get<string>(0));
-            Assert.Throws<ArgumentNullException>(() => new ArgumentCollection(valueTypeMethod.GetParameters(), new object[] { null }).Get<string>("value"));
+            Assert.Throws<ArgumentNullException>(() => new ArgumentCollection(new ObjectArgument(referenceTypeMethod.GetParameters()[0], null)).Get<string>(0));
+            Assert.Throws<ArgumentNullException>(() => new ArgumentCollection(new ObjectArgument(referenceTypeMethod.GetParameters()[0], null)).Get<string>("value"));
         }
 
         [Fact]
         public void GetTypedThrowsIfIncompatible()
         {
-            Assert.Throws<ArgumentException>(() => new ArgumentCollection(valueTypeMethod.GetParameters(), "foo").Get<int>(0));
-            Assert.Throws<ArgumentException>(() => new ArgumentCollection(valueTypeMethod.GetParameters(), "foo").Get<int>("value"));
+            Assert.Throws<ArgumentException>(() => ArgumentCollection.Create(referenceTypeMethod.GetParameters(), "foo").Get<int>(0));
+            Assert.Throws<ArgumentException>(() => ArgumentCollection.Create(referenceTypeMethod.GetParameters(), "foo").Get<int>("value"));
         }
 
         [Fact]
@@ -153,5 +134,12 @@ namespace Avatars.UnitTests
         public static void DoNullableValueType(int? value) { }
         public static void DoReferenceType(string value) { }
         public static void DoMultiple(string message, int count, bool enabled) { }
+    }
+
+    public class CustomType
+    {
+        public CustomType(int value) => Value = value;
+
+        public int Value { get; }
     }
 }

--- a/src/Avatar.UnitTests/ArgumentTests.cs
+++ b/src/Avatar.UnitTests/ArgumentTests.cs
@@ -1,0 +1,252 @@
+﻿using System;
+using TypeNameFormatter;
+using Xunit;
+
+namespace Avatars.UnitTests
+{
+    public class ArgumentTests
+    {
+        [Fact]
+        public void WhenObjectValueIsCompatible_ThenRawValueEqualsValue()
+        {
+            var parameter = typeof(ArgumentTests).GetMethod(nameof(Arguments)).GetParameters()[4];
+            var value = new object();
+
+            var argument = new ObjectArgument(parameter, value);
+
+            Assert.Same(value, argument.RawValue);
+        }
+
+        [Fact]
+        public void WhenObjectValueIsNotCompatible_ThenThrowsArgumentException()
+        {
+            var parameter = typeof(ArgumentTests).GetMethod(nameof(Arguments)).GetParameters()[2];
+
+            Assert.Throws<ArgumentException>(() => new ObjectArgument(parameter, 42));
+        }
+
+        [Fact]
+        public void WhenObjectValueIsNull_ThenSucceedsForReferenceType()
+        {
+            var parameter = typeof(ArgumentTests).GetMethod(nameof(Arguments)).GetParameters()[2];
+
+            var argument = new ObjectArgument(parameter, null);
+
+            Assert.Null(argument.RawValue);
+        }
+
+        [Fact]
+        public void WhenObjectValueIsCompatible_ThenSucceedsForRefParameter()
+        {
+            var parameter = typeof(ArgumentTests).GetMethod(nameof(Arguments)).GetParameters()[3];
+
+            var argument = new ObjectArgument(parameter, "foo");
+
+            Assert.Equal("foo", argument.RawValue);
+        }
+
+        [Fact]
+        public void WhenObjectValueIsNotNull_ThenSucceedsForOutParameter()
+        {
+            var parameter = typeof(ArgumentTests).GetMethod(nameof(Arguments)).GetParameters()[5];
+
+            var argument = new ObjectArgument(parameter, PlatformID.Win32NT);
+
+            Assert.Equal(PlatformID.Win32NT, argument.RawValue);
+        }
+
+        [Fact]
+        public void WhenObjectValueIsNullForOutNullable_ThenSucceeds()
+        {
+            var parameter = typeof(ArgumentTests).GetMethod(nameof(Arguments)).GetParameters()[5];
+
+            var argument = new ObjectArgument(parameter, null);
+
+            Assert.Null(argument.RawValue);
+        }
+
+        [Fact]
+        public void WhenObjectValueIsNullForValueType_ThenThrowsArgumentNullException()
+        {
+            var parameter = typeof(ArgumentTests).GetMethod(nameof(Arguments)).GetParameters()[0];
+
+            Assert.Throws<ArgumentNullException>(() => new ObjectArgument(parameter, null));
+        }
+
+        [Fact]
+        public void WhenObjectValueIsNullForNullableValueType_ThenSucceeds()
+        {
+            var parameter = typeof(ArgumentTests).GetMethod(nameof(Arguments)).GetParameters()[1];
+
+            var argument = new ObjectArgument(parameter, null);
+
+            Assert.Null(argument.RawValue);
+        }
+
+        [Fact]
+        public void WhenObjectValueAssignedNewValue_ThenNewInstanceReturned()
+        {
+            var parameter = typeof(ArgumentTests).GetMethod(nameof(Arguments)).GetParameters()[4];
+            var value = new object();
+
+            var argument = new ObjectArgument(parameter, value);
+
+            var updated = argument.WithRawValue(new object());
+
+            Assert.NotSame(argument, updated);
+            Assert.NotSame(argument.RawValue, updated.RawValue);
+        }
+
+        [Fact]
+        public void WhenObjectValueAssignedIncompatibleNewValue_ThenThrowsArgumentException()
+        {
+            var parameter = typeof(ArgumentTests).GetMethod(nameof(Arguments)).GetParameters()[0];
+            var argument = new ObjectArgument(parameter, 42);
+
+            Assert.Throws<ArgumentException>(() => argument.WithRawValue("foo"));
+        }
+
+        [Fact]
+        public void WhenComparingArguments_ThenComparesStructurally()
+        {
+            var parameter = typeof(ArgumentTests).GetMethod(nameof(Arguments)).GetParameters()[0];
+            var first = new ObjectArgument(parameter, 42);
+            var second = new ObjectArgument(parameter, 42);
+
+            Assert.Equal(first, second);
+            Assert.NotEqual(first, second.WithRawValue(24));
+        }
+
+
+
+
+
+
+
+        [Fact]
+        public void WhenTypedValueIsCompatible_ThenRawValueEqualsValue()
+        {
+            var parameter = typeof(ArgumentTests).GetMethod(nameof(Arguments)).GetParameters()[2];
+
+            var argument = Argument.Create(parameter, "foo");
+
+            Assert.Equal("foo", argument.Value);
+        }
+
+        [Fact]
+        public void WhenTypedValueIsNotCompatible_ThenThrowsArgumentException()
+        {
+            var parameter = typeof(ArgumentTests).GetMethod(nameof(Arguments)).GetParameters()[2];
+
+            Assert.Throws<ArgumentException>(() => Argument.Create(parameter, 42));
+        }
+
+        [Fact]
+        public void WhenTypeIsNotCompatible_ThenThrowsArgumentException()
+        {
+            var parameter = typeof(ArgumentTests).GetMethod(nameof(Arguments)).GetParameters()[0];
+
+            Assert.Throws<ArgumentException>(() => Argument.Create(parameter, "foo"));
+        }
+
+        [Fact]
+        public void WhenTypeIsNullableValueTypeButParameterIsNot_ThenThrowsArgumentException()
+        {
+            var parameter = typeof(ArgumentTests).GetMethod(nameof(Arguments)).GetParameters()[0];
+
+            Assert.Throws<ArgumentException>(() => Argument.Create<int?>(parameter, 42));
+        }
+
+        [Fact]
+        public void WhenTypeIsNotNullableValueTypeButParameterIs_ThenSucceeds()
+        {
+            var parameter = typeof(ArgumentTests).GetMethod(nameof(Arguments)).GetParameters()[1];
+
+            var argument = Argument.Create(parameter, 42);
+
+            Assert.Equal(42, argument.Value);
+        }
+
+        [Fact]
+        public void WhenTypedValueIsNull_ThenSucceedsForReferenceType()
+        {
+            var parameter = typeof(ArgumentTests).GetMethod(nameof(Arguments)).GetParameters()[2];
+
+            var argument = new ObjectArgument(parameter, null);
+
+            Assert.Null(argument.RawValue);
+        }
+
+        [Fact]
+        public void WhenTypedValueIsNullForNullableValueType_ThenSucceeds()
+        {
+            var parameter = typeof(ArgumentTests).GetMethod(nameof(Arguments)).GetParameters()[1];
+
+            var argument = new ObjectArgument(parameter, null);
+
+            Assert.Null(argument.RawValue);
+        }
+
+        [Fact]
+        public void WhenTypedValueAssignedNewValue_ThenNewInstanceReturned()
+        {
+            var parameter = typeof(ArgumentTests).GetMethod(nameof(Arguments)).GetParameters()[2];
+
+            var argument = Argument.Create(parameter, "foo");
+
+            var updated = argument.WithValue("bar");
+
+            Assert.NotEqual(argument, updated);
+            Assert.NotEqual(argument.RawValue, updated.RawValue);
+        }
+
+        [Fact]
+        public void WhenTypedValueAssignedIncompatibleRawValue_ThenThrowsArgumentException()
+        {
+            var parameter = typeof(ArgumentTests).GetMethod(nameof(Arguments)).GetParameters()[2];
+
+            var argument = Argument.Create(parameter, "foo");
+
+            Assert.Throws<ArgumentException>(() => argument.WithRawValue(42));
+        }
+
+        [Fact]
+        public void WhenTypedValueAssignedNullRawValue_ThenSucceedsForReferenceType()
+        {
+            var parameter = typeof(ArgumentTests).GetMethod(nameof(Arguments)).GetParameters()[2];
+
+            var argument = Argument.Create(parameter, "foo");
+
+            Assert.Null(argument.WithRawValue(null).RawValue);
+        }
+
+        [Fact]
+        public void WhenComparingTypedArguments_ThenComparesStructurally()
+        {
+            var parameter = typeof(ArgumentTests).GetMethod(nameof(Arguments)).GetParameters()[0];
+            var first = Argument.Create(parameter, 42);
+            var second = Argument.Create(parameter, 42);
+
+            Assert.Equal(first, second);
+            Assert.NotEqual(first, second.WithRawValue(24));
+        }
+
+        [Fact]
+        public void WhenUpdatingValue_ThenCanUseRecordsSyntax()
+        {
+            var parameter = typeof(ArgumentTests).GetMethod(nameof(Arguments)).GetParameters()[0];
+
+            var first = Argument.Create(parameter, 42);
+            var second = first with { Value = 24 };
+
+            Assert.Equal(24, second.Value);
+        }
+
+
+#pragma warning disable xUnit1013 // Public method should be marked as test
+        public void Arguments(int arg0, int? arg1, string arg2, ref string? arg3, object arg4, out PlatformID? arg5)
+        {
+            arg5 = default;
+        }
+    }
+}

--- a/src/Avatar.UnitTests/AvatarGeneratorTests.cs
+++ b/src/Avatar.UnitTests/AvatarGeneratorTests.cs
@@ -33,21 +33,21 @@ namespace Avatars.UnitTests
     {
         readonly BehaviorPipeline pipeline = BehaviorPipelineFactory.Default.CreatePipeline<BaseClassAvatar>();
         [CompilerGenerated]
-        public BaseClassAvatar() => pipeline.Execute(new MethodInvocation(this, MethodBase.GetCurrentMethod(), (m, n) => m.CreateValueReturn(this, m.Arguments)));
+        public BaseClassAvatar() => pipeline.Execute(MethodInvocation.Create(this, MethodBase.GetCurrentMethod(), (m, n) => m.CreateValueReturn(this, m.Arguments)));
         [CompilerGenerated]
         IList<IAvatarBehavior> IAvatar.Behaviors => pipeline.Behaviors;
         [CompilerGenerated]
-        public override bool Equals(object obj) => pipeline.Execute<bool>(new MethodInvocation(this, MethodBase.GetCurrentMethod(), (m, n) => m.CreateValueReturn(base.Equals(obj), obj), obj));
+        public override bool Equals(object obj) => pipeline.Execute<bool>(MethodInvocation.Create(this, MethodBase.GetCurrentMethod(), (m, n) => m.CreateValueReturn(base.Equals(obj), obj), obj));
         [CompilerGenerated]
-        public override int GetHashCode() => pipeline.Execute<int>(new MethodInvocation(this, MethodBase.GetCurrentMethod(), (m, n) => m.CreateValueReturn(base.GetHashCode())));
+        public override int GetHashCode() => pipeline.Execute<int>(MethodInvocation.Create(this, MethodBase.GetCurrentMethod(), (m, n) => m.CreateValueReturn(base.GetHashCode())));
         [CompilerGenerated]
-        public override string ToString() => pipeline.Execute<string>(new MethodInvocation(this, MethodBase.GetCurrentMethod(), (m, n) => m.CreateValueReturn(base.ToString())));
+        public override string ToString() => pipeline.Execute<string>(MethodInvocation.Create(this, MethodBase.GetCurrentMethod(), (m, n) => m.CreateValueReturn(base.ToString())));
         [CompilerGenerated]
         public override bool TryMixed(int x, int? y, ref string name, out int? z)
         {
             var _method = MethodBase.GetCurrentMethod();
             z = default;
-            var _result = pipeline.Invoke(new MethodInvocation(this, _method, (m, n) =>
+            var _result = pipeline.Invoke(MethodInvocation.Create(this, _method, (m, n) =>
             {
                 var _name = m.Arguments.Get<string>("name");
                 var _z = m.Arguments.Get<int?>("z");

--- a/src/Avatar.UnitTests/BehaviorPipelineTests.cs
+++ b/src/Avatar.UnitTests/BehaviorPipelineTests.cs
@@ -21,8 +21,8 @@ namespace Avatars.UnitTests
 
             Action a = WhenInvokingPipelineWithNoBehaviors_ThenInvokesTarget;
 
-            pipeline.Invoke(new MethodInvocation(this, a.GetMethodInfo(),
-                (m, n) => { targetCalled = true; return m.CreateValueReturn(null); }));
+            pipeline.Invoke(MethodInvocation.Create(this, a.GetMethodInfo(),
+                (m, n) => { targetCalled = true; return m.CreateReturn(); }));
 
             Assert.True(targetCalled);
         }
@@ -51,8 +51,8 @@ namespace Avatars.UnitTests
 
             Action a = WhenInvokingPipeline_ThenInvokesAllBehaviorsAndTarget;
 
-            pipeline.Invoke(new MethodInvocation(this, a.GetMethodInfo(),
-                (m, n) => { targetCalled = true; return m.CreateValueReturn(null); }));
+            pipeline.Invoke(MethodInvocation.Create(this, a.GetMethodInfo(),
+                (m, n) => { targetCalled = true; return m.CreateReturn(); }));
 
             Assert.True(firstCalled);
             Assert.True(secondCalled);
@@ -72,8 +72,8 @@ namespace Avatars.UnitTests
 
             Action a = WhenInvokingPipelineWithNoApplicableBehaviors_ThenInvokesTarget;
 
-            pipeline.Invoke(new MethodInvocation(this, a.GetMethodInfo(),
-                (m, n) => { targetCalled = true; return m.CreateValueReturn(null); }));
+            pipeline.Invoke(MethodInvocation.Create(this, a.GetMethodInfo(),
+                (m, n) => { targetCalled = true; return m.CreateReturn(); }));
 
             Assert.False(firstCalled);
             Assert.False(secondCalled);
@@ -93,8 +93,8 @@ namespace Avatars.UnitTests
 
             Action a = WhenInvokingPipeline_ThenInvokesAllBehaviorsAndTarget;
 
-            pipeline.Invoke(new MethodInvocation(this, a.GetMethodInfo(),
-                (m, n) => { targetCalled = true; return m.CreateValueReturn(null); }));
+            pipeline.Invoke(MethodInvocation.Create(this, a.GetMethodInfo(),
+                (m, n) => { targetCalled = true; return m.CreateReturn(); }));
 
             Assert.True(firstCalled);
             Assert.False(secondCalled);
@@ -109,13 +109,13 @@ namespace Avatars.UnitTests
             var targetCalled = false;
 
             var pipeline = new BehaviorPipeline(
-                new ExecuteDelegate((m, n) => { firstCalled = true; return m.CreateValueReturn(null); }),
+                new ExecuteDelegate((m, n) => { firstCalled = true; return m.CreateReturn(); }),
                 new ExecuteDelegate((m, n) => { secondCalled = true; return n().Invoke(m, n); }));
 
             Action a = WhenInvokingPipeline_ThenBehaviorCanShortcircuitInvocation;
 
-            pipeline.Invoke(new MethodInvocation(this, a.GetMethodInfo(),
-                (m, n) => { targetCalled = true; return m.CreateValueReturn(null); }));
+            pipeline.Invoke(MethodInvocation.Create(this, a.GetMethodInfo(),
+                (m, n) => { targetCalled = true; return m.CreateReturn(); }));
 
             Assert.True(firstCalled);
             Assert.False(secondCalled);
@@ -134,7 +134,7 @@ namespace Avatars.UnitTests
 
             Action a = WhenInvokingPipeline_ThenBehaviorsCanPassDataWithContext;
 
-            var result = pipeline.Invoke(new MethodInvocation(this, a.GetMethodInfo(), (m, n) => m.CreateValueReturn(null)));
+            var result = pipeline.Invoke(MethodInvocation.Create(this, a.GetMethodInfo(), (m, n) => m.CreateReturn()));
 
             Assert.Equal(expected, actual);
             Assert.True(result.Context.ContainsKey("guid"));
@@ -151,7 +151,7 @@ namespace Avatars.UnitTests
 
             Func<object?> a = NonVoidMethod;
 
-            var result = pipeline.Invoke(new MethodInvocation(this, a.GetMethodInfo()));
+            var result = pipeline.Invoke(MethodInvocation.Create(this, a.GetMethodInfo()));
 
             Assert.Equal(expected, result.ReturnValue);
         }
@@ -166,7 +166,7 @@ namespace Avatars.UnitTests
 
             Func<object, object?> a = NonVoidMethodWithArg;
 
-            var result = pipeline.Invoke(new MethodInvocation(this, a.GetMethodInfo(), expected));
+            var result = pipeline.Invoke(MethodInvocation.Create(this, a.GetMethodInfo(), expected));
 
             Assert.Equal(expected, result.ReturnValue);
         }
@@ -182,7 +182,7 @@ namespace Avatars.UnitTests
 
             NonVoidMethodWithArgRefDelegate a = NonVoidMethodWithArgRef;
 
-            var result = pipeline.Invoke(new MethodInvocation(this, a.GetMethodInfo(), expected, output));
+            var result = pipeline.Invoke(MethodInvocation.Create(this, a.GetMethodInfo(), expected, output));
 
             Assert.Equal(expected, result.ReturnValue);
             Assert.Equal(output, result.Outputs.GetValue(0));
@@ -196,7 +196,7 @@ namespace Avatars.UnitTests
 
             Action a = WhenInvokingPipeline_ThenBehaviorsCanReturnException;
 
-            Assert.Throws<ArgumentException>(() => pipeline.Invoke(new MethodInvocation(this, a.GetMethodInfo(), true)));
+            Assert.Throws<ArgumentException>(() => pipeline.Invoke(MethodInvocation.Create(this, a.GetMethodInfo()), true));
         }
 
         [Fact]
@@ -210,8 +210,7 @@ namespace Avatars.UnitTests
 
             NonVoidMethodWithArgOutDelegate a = NonVoidMethodWithArgOut;
 
-            var result = pipeline.Invoke(new MethodInvocation(this, a.GetMethodInfo(),
-                expected, output));
+            var result = pipeline.Invoke(MethodInvocation.Create(this, a.GetMethodInfo(), expected, output));
 
             Assert.Equal(expected, result.ReturnValue);
             Assert.Equal(output, result.Outputs.GetValue(0));
@@ -229,7 +228,7 @@ namespace Avatars.UnitTests
 
             NonVoidMethodWithArgRefOutDelegate a = NonVoidMethodWithArgRefOut;
 
-            var result = pipeline.Invoke(new MethodInvocation(this, a.GetMethodInfo(), expected, byref, output));
+            var result = pipeline.Invoke(MethodInvocation.Create(this, a.GetMethodInfo(), expected, byref, output));
 
             Assert.Equal(expected, result.ReturnValue);
             Assert.Equal(byref, result.Outputs.GetValue(0));
@@ -245,7 +244,7 @@ namespace Avatars.UnitTests
 
             Func<object?> f = NonVoidMethod;
 
-            Assert.Same(value, pipeline.Execute<object>(new MethodInvocation(this, f.GetMethodInfo())));
+            Assert.Same(value, pipeline.Execute<object>(MethodInvocation.Create(this, f.GetMethodInfo())));
         }
 
         [Fact]
@@ -257,14 +256,14 @@ namespace Avatars.UnitTests
 
             Func<object?> f = NonVoidMethod;
 
-            Assert.Same(value, pipeline.Execute<object>(new MethodInvocation(this, f.GetMethodInfo(),
+            Assert.Same(value, pipeline.Execute<object>(MethodInvocation.Create(this, f.GetMethodInfo(),
                 (m, n) => m.CreateValueReturn(value))));
         }
 
         [Fact]
         public void CanExecutePipelineNoTarget()
         {
-            var pipeline = new BehaviorPipeline(new ExecuteDelegate((m, n) => m.CreateValueReturn(null)));
+            var pipeline = new BehaviorPipeline(new ExecuteDelegate((m, n) => m.CreateReturn()));
 
             Action a = CanExecutePipelineNoTarget;
 
@@ -278,7 +277,7 @@ namespace Avatars.UnitTests
 
             Action a = CanExecutePipelineWithTarget;
 
-            pipeline.Execute(new MethodInvocation(this, a.GetMethodInfo(), (m, n) => m.CreateValueReturn(null)));
+            pipeline.Execute(MethodInvocation.Create(this, a.GetMethodInfo(), (m, n) => m.CreateReturn()));
         }
 
         [Fact]
@@ -288,7 +287,8 @@ namespace Avatars.UnitTests
 
             Action a = CanExecutePipelineNoTarget;
 
-            Assert.Throws<NotImplementedException>(() => pipeline.Execute(new MethodInvocation(this, a.GetMethodInfo())));
+            Assert.Throws<NotImplementedException>(()
+                => pipeline.Execute(MethodInvocation.Create(this, a.GetMethodInfo())));
         }
 
         [Fact]
@@ -300,7 +300,7 @@ namespace Avatars.UnitTests
             Action a = WhenInvokingPipeline_ThenBehaviorsCanReturnException;
 
             Assert.Throws<ArgumentException>(()
-                => pipeline.Execute(new MethodInvocation(this, a.GetMethodInfo())));
+                => pipeline.Execute(MethodInvocation.Create(this, a.GetMethodInfo())));
         }
 
         [Fact]
@@ -312,7 +312,7 @@ namespace Avatars.UnitTests
             Func<object?> f = NonVoidMethod;
 
             Assert.Throws<ArgumentException>(()
-                => pipeline.Execute<object>(new MethodInvocation(this, f.GetMethodInfo())));
+                => pipeline.Execute<object>(MethodInvocation.Create(this, f.GetMethodInfo())));
         }
 
         [Fact]
@@ -323,7 +323,7 @@ namespace Avatars.UnitTests
             Func<object?> f = NonVoidMethod;
 
             Assert.Throws<NotImplementedException>(()
-                => pipeline.Execute<object>(new MethodInvocation(this, f.GetMethodInfo())));
+                => pipeline.Execute<object>(MethodInvocation.Create(this, f.GetMethodInfo())));
         }
 
         [Fact]
@@ -333,7 +333,7 @@ namespace Avatars.UnitTests
 
             pipeline.Behaviors.Add(new TestBehavior());
 
-            var invocation = new MethodInvocation(new object(), typeof(object).GetMethod("ToString")!);
+            var invocation = MethodInvocation.Create(new object(), typeof(object).GetMethod("ToString")!);
             invocation.SkipBehavior<TestBehavior>();
 
             Assert.Throws<NotImplementedException>(()

--- a/src/Avatar.UnitTests/DefaultEqualityBehaviorTests.cs
+++ b/src/Avatar.UnitTests/DefaultEqualityBehaviorTests.cs
@@ -10,7 +10,7 @@ namespace Avatars.UnitTests
             var method = typeof(Foo).GetMethod(nameof(object.GetHashCode))!;
             var behavior = new DefaultEqualityBehavior();
 
-            Assert.True(behavior.AppliesTo(new MethodInvocation(new Foo(), method, new object[0])));
+            Assert.True(behavior.AppliesTo(MethodInvocation.Create(new Foo(), method)));
         }
 
         [Fact]
@@ -19,7 +19,7 @@ namespace Avatars.UnitTests
             var method = typeof(Foo).GetMethod(nameof(object.Equals))!;
             var behavior = new DefaultEqualityBehavior();
 
-            Assert.True(behavior.AppliesTo(new MethodInvocation(new Foo(), method, new object[] { new Foo() })));
+            Assert.True(behavior.AppliesTo(MethodInvocation.Create(new Foo(), method, new Foo())));
         }
 
         [Fact]
@@ -30,7 +30,7 @@ namespace Avatars.UnitTests
             var target = new Foo();
 
             var expected = target.GetHashCode();
-            var actual = (int?)behavior.Execute(new MethodInvocation(target, method, new object[0]), () => null!).ReturnValue;
+            var actual = (int?)behavior.Execute(MethodInvocation.Create(target, method), () => null!).ReturnValue;
 
             Assert.Equal(expected, actual);
         }
@@ -42,7 +42,7 @@ namespace Avatars.UnitTests
             var behavior = new DefaultEqualityBehavior();
             var target = new Foo();
 
-            var actual = (bool?)behavior.Execute(new MethodInvocation(target, method, new object[] { target }), () => null!).ReturnValue;
+            var actual = (bool?)behavior.Execute(MethodInvocation.Create(target, method, target), () => null!).ReturnValue;
 
             Assert.True(actual);
         }
@@ -54,7 +54,7 @@ namespace Avatars.UnitTests
             var behavior = new DefaultEqualityBehavior();
             var target = new Foo();
 
-            var actual = (bool?)behavior.Execute(new MethodInvocation(target, method, new object[] { new Foo() }), () => null!).ReturnValue;
+            var actual = (bool?)behavior.Execute(MethodInvocation.Create(target, method, new Foo()), () => null!).ReturnValue;
 
             Assert.False(actual);
         }
@@ -68,11 +68,11 @@ namespace Avatars.UnitTests
             var nextCalled = false;
 
             behavior.Execute(
-                new MethodInvocation(target, method),
+                MethodInvocation.Create(target, method),
                 () => (m, n) =>
                 {
                     nextCalled = true;
-                    return m.CreateValueReturn(null);
+                    return m.CreateReturn();
                 });
 
             Assert.True(nextCalled);

--- a/src/Avatar.UnitTests/DefaultValueTests.cs
+++ b/src/Avatar.UnitTests/DefaultValueTests.cs
@@ -14,9 +14,9 @@ namespace Avatars.UnitTests
         {
             var method = typeof(IDefaultValues).GetMethod(nameof(IDefaultValues.VoidWithRef))!;
             IAvatarBehavior behavior = new DefaultValueBehavior();
-            var value = new object();
+            var value = new object[] { new object() };
 
-            var result = behavior.Execute(new MethodInvocation(new object(), method, value), () => null!);
+            var result = behavior.Execute(MethodInvocation.Create(new object(), method, value), () => null!);
 
             Assert.Equal(1, result.Outputs.Count);
             Assert.NotNull(result.Outputs.GetValue(0));
@@ -30,7 +30,7 @@ namespace Avatars.UnitTests
             IAvatarBehavior behavior = new DefaultValueBehavior();
             var platform = PlatformID.Xbox;
 
-            var result = behavior.Execute(new MethodInvocation(new object(), method, platform), () => null!);
+            var result = behavior.Execute(MethodInvocation.Create(new object(), method, platform), () => null!);
 
             Assert.Equal(1, result.Outputs.Count);
             Assert.NotNull(result.Outputs.GetValue(0));
@@ -43,7 +43,7 @@ namespace Avatars.UnitTests
             var method = typeof(IDefaultValues).GetMethod(nameof(IDefaultValues.VoidWithOut))!;
             IAvatarBehavior behavior = new DefaultValueBehavior();
 
-            var result = behavior.Execute(new MethodInvocation(new object(), method, new object[1]), () => null!);
+            var result = behavior.Execute(MethodInvocation.Create(new object(), method, new object[0]), () => null!);
 
             Assert.Equal(1, result.Outputs.Count);
             Assert.NotNull(result.Outputs.GetValue(0));
@@ -56,7 +56,7 @@ namespace Avatars.UnitTests
             var method = typeof(IDefaultValues).GetMethod(nameof(IDefaultValues.ReturnEnum))!;
             IAvatarBehavior behavior = new DefaultValueBehavior();
 
-            var result = behavior.Execute(new MethodInvocation(new object(), method, new object[0]), () => null!);
+            var result = behavior.Execute(MethodInvocation.Create(new object(), method), () => null!);
 
             Assert.Equal(default(PlatformID), result.ReturnValue);
         }
@@ -67,7 +67,7 @@ namespace Avatars.UnitTests
             var ctor = typeof(Foo).GetConstructors().First();
             IAvatarBehavior behavior = new DefaultValueBehavior();
 
-            behavior.Execute(new MethodInvocation(new object(), ctor, new object[1]), () => null!);
+            behavior.Execute(MethodInvocation.Create(new object(), ctor, PlatformID.Win32NT), () => null!);
         }
 
         [Fact]

--- a/src/Avatar.UnitTests/MethodInvocationTests.cs
+++ b/src/Avatar.UnitTests/MethodInvocationTests.cs
@@ -24,7 +24,7 @@ namespace Avatars.UnitTests
         [Fact]
         public void TestDoWithInt()
         {
-            var invocation = new MethodInvocation(this, typeof(MethodInvocationTests).GetMethod(nameof(DoWithInt))!, 5);
+            var invocation = MethodInvocation.Create(this, typeof(MethodInvocationTests).GetMethod(nameof(DoWithInt))!, 5);
 
             var actual = invocation.ToString();
 
@@ -34,8 +34,8 @@ namespace Avatars.UnitTests
         [Fact]
         public void EqualIfTargetMethodAndArgumentsMatch()
         {
-            var doThis = new MethodInvocation(this, typeof(MethodInvocationTests).GetMethod(nameof(Do))!);
-            var doThiss = new MethodInvocation(this, typeof(MethodInvocationTests).GetMethod(nameof(Do))!);
+            var doThis = MethodInvocation.Create(this, typeof(MethodInvocationTests).GetMethod(nameof(Do))!);
+            var doThiss = MethodInvocation.Create(this, typeof(MethodInvocationTests).GetMethod(nameof(Do))!);
 
             Assert.Equal((object)doThis, doThiss);
             Assert.Equal(doThis, doThiss);
@@ -43,23 +43,23 @@ namespace Avatars.UnitTests
             Assert.True(doThis.Equals(doThiss));
             Assert.True(doThis.Equals((object)doThiss));
 
-            var doOther = new MethodInvocation(new MethodInvocationTests(), typeof(MethodInvocationTests).GetMethod(nameof(Do))!);
+            var doOther = MethodInvocation.Create(new MethodInvocationTests(), typeof(MethodInvocationTests).GetMethod(nameof(Do))!);
 
             Assert.NotEqual(doThis, doOther);
 
-            var doInt5 = new MethodInvocation(this, typeof(MethodInvocationTests).GetMethod(nameof(DoWithInt))!, 5);
-            var doInt5s = new MethodInvocation(this, typeof(MethodInvocationTests).GetMethod(nameof(DoWithInt))!, 5);
+            var doInt5 = MethodInvocation.Create(this, typeof(MethodInvocationTests).GetMethod(nameof(DoWithInt))!, 5);
+            var doInt5s = MethodInvocation.Create(this, typeof(MethodInvocationTests).GetMethod(nameof(DoWithInt))!, 5);
 
             Assert.NotEqual(doThis, doInt5);
             Assert.Equal(doInt5, doInt5s);
             Assert.Equal(doInt5.GetHashCode(), doInt5s.GetHashCode());
 
-            var doInt6 = new MethodInvocation(this, typeof(MethodInvocationTests).GetMethod(nameof(DoWithInt))!, 6);
+            var doInt6 = MethodInvocation.Create(this, typeof(MethodInvocationTests).GetMethod(nameof(DoWithInt))!, 6);
 
             Assert.NotEqual(doInt5, doInt6);
 
-            var doIntNull = new MethodInvocation(this, typeof(MethodInvocationTests).GetMethod(nameof(DoWithNullableInt))!, 5);
-            var doIntNulls = new MethodInvocation(this, typeof(MethodInvocationTests).GetMethod(nameof(DoWithNullableInt))!, new object[] { null! });
+            var doIntNull = MethodInvocation.Create(this, typeof(MethodInvocationTests).GetMethod(nameof(DoWithNullableInt))!, 5);
+            var doIntNulls = MethodInvocation.Create(this, typeof(MethodInvocationTests).GetMethod(nameof(DoWithNullableInt))!, default(int?));
 
             Assert.NotEqual(doIntNull, doIntNulls);
             Assert.NotEqual(doIntNull.GetHashCode(), doIntNulls.GetHashCode());
@@ -70,7 +70,7 @@ namespace Avatars.UnitTests
         [Fact]
         public void TestDoWithNullableInt()
         {
-            var invocation = new MethodInvocation(this, typeof(MethodInvocationTests).GetMethod(nameof(DoWithNullableInt))!, 5);
+            var invocation = MethodInvocation.Create(this, typeof(MethodInvocationTests).GetMethod(nameof(DoWithNullableInt))!, 5);
 
             var actual = invocation.ToString();
 
@@ -82,7 +82,7 @@ namespace Avatars.UnitTests
         [Fact]
         public void TestDoWithNullableIntNull()
         {
-            var invocation = new MethodInvocation(this, typeof(MethodInvocationTests).GetMethod(nameof(DoWithNullableIntNull))!, default(int?));
+            var invocation = MethodInvocation.Create(this, typeof(MethodInvocationTests).GetMethod(nameof(DoWithNullableIntNull))!, default(int?));
 
             var actual = invocation.ToString();
 
@@ -94,7 +94,7 @@ namespace Avatars.UnitTests
         [Fact]
         public void TestDoWithString()
         {
-            var invocation = new MethodInvocation(this, typeof(MethodInvocationTests).GetMethod(nameof(DoWithString))!, "foo");
+            var invocation = MethodInvocation.Create(this, typeof(MethodInvocationTests).GetMethod(nameof(DoWithString))!, "foo");
 
             var actual = invocation.ToString();
 
@@ -106,7 +106,7 @@ namespace Avatars.UnitTests
         [Fact]
         public void TestDoWithNullString()
         {
-            var invocation = new MethodInvocation(this, typeof(MethodInvocationTests).GetMethod(nameof(DoWithNullString))!, default(string));
+            var invocation = MethodInvocation.Create(this, typeof(MethodInvocationTests).GetMethod(nameof(DoWithNullString))!, default(string));
 
             var actual = invocation.ToString();
 
@@ -118,7 +118,7 @@ namespace Avatars.UnitTests
         [Fact]
         public void TestDoReturn()
         {
-            var invocation = new MethodInvocation(this, typeof(MethodInvocationTests).GetMethod(nameof(DoReturn))!);
+            var invocation = MethodInvocation.Create(this, typeof(MethodInvocationTests).GetMethod(nameof(DoReturn))!);
 
             var actual = invocation.ToString();
 
@@ -130,7 +130,7 @@ namespace Avatars.UnitTests
         [Fact]
         public void TestDoRef()
         {
-            var invocation = new MethodInvocation(this, typeof(MethodInvocationTests).GetMethod(nameof(DoRef))!, 5);
+            var invocation = MethodInvocation.Create(this, typeof(MethodInvocationTests).GetMethod(nameof(DoRef))!, 5);
 
             var actual = invocation.ToString();
 
@@ -142,7 +142,7 @@ namespace Avatars.UnitTests
         [Fact]
         public void TestDoOut()
         {
-            var invocation = new MethodInvocation(this, typeof(MethodInvocationTests).GetMethod(nameof(DoOut))!, 5);
+            var invocation = MethodInvocation.Create(this, typeof(MethodInvocationTests).GetMethod(nameof(DoOut))!, 5);
 
             var actual = invocation.ToString();
 
@@ -161,7 +161,7 @@ namespace Avatars.UnitTests
         public void ReturnOutputsContainsRefAndOut()
         {
             var calculator = new Calculator();
-            var invocation = new MethodInvocation(calculator, typeof(ICalculator).GetMethod(nameof(ICalculator.TryAdd))!, 2, 3, 5);
+            var invocation = MethodInvocation.Create(calculator, typeof(ICalculator).GetMethod(nameof(ICalculator.TryAdd))!, 2, 3, 5);
 
             var result = invocation.CreateValueReturn(true);
 

--- a/src/Avatar.UnitTests/RefReturns.cs
+++ b/src/Avatar.UnitTests/RefReturns.cs
@@ -41,7 +41,7 @@ namespace Avatars.UnitTests
                 count = default;
                 var local_index = index;
 
-                var returns = pipeline.Execute(new MethodInvocation(this, MethodBase.GetCurrentMethod(), local_index, count));
+                var returns = pipeline.Execute(MethodInvocation.Create(this, MethodBase.GetCurrentMethod(), local_index, count));
                 index = returns.Outputs.GetNullable<int>("index");
                 count = returns.Outputs.GetNullable<int>("count");
 

--- a/src/Avatar/Argument.cs
+++ b/src/Avatar/Argument.cs
@@ -1,0 +1,184 @@
+﻿using System;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
+using TypeNameFormatter;
+
+namespace Avatars
+{
+    /// <summary>
+    /// Base class for arguments to an invocation, a tuple of the 
+    /// declaring <see cref="ParameterInfo"/> and its value.
+    /// </summary>
+    /// <remarks>
+    /// When using <see cref="RawValue"/> and <see cref="WithRawValue"/> 
+    /// (to get a new changed record instance), the value is boxed correspondingly 
+    /// to the .NET rules for structs. Therefore, it's always recommended to attempt 
+    /// casting the base <see cref="Argument"/> to a <see cref="Argument{T}"/> if 
+    /// you know the type ahead of time, to avoid unnecessary boxing.
+    /// </remarks>
+    public abstract record Argument
+    {
+        /// <summary>
+        /// Creates a typed argument.
+        /// </summary>
+        /// <typeparam name="T">The type of the argument, typically inferred from the <paramref name="value"/> type.</typeparam>
+        /// <param name="info">The <see cref="ParameterInfo"/> that declares the argument in a method or constructor.</param>
+        /// <param name="value">The argument value.</param>
+        public static Argument<T> Create<T>(ParameterInfo info, T value) => new Argument<T>(info, value);
+
+        /// <summary>
+        /// Creates the argument with the given <paramref name="parameter"/>.
+        /// <param name="parameter">The <see cref="ParameterInfo"/> that declares the argument in a method or constructor.</param>
+        /// </summary>
+        protected Argument(ParameterInfo parameter) => Parameter = parameter;
+
+        /// <summary>
+        /// Gets the name of the argument from <see cref="ParameterInfo.Name"/> 
+        /// through the <see cref="Parameter"/> property.
+        /// </summary>
+        public string Name => Parameter.Name;
+
+        /// <summary>
+        /// The <see cref="ParameterInfo"/> that declares the argument in a method or constructor.
+        /// </summary>
+        public ParameterInfo Parameter { get; init; }
+
+        /// <summary>
+        /// Gets the raw, potentially boxed (for value types) value for the argument.
+        /// </summary>
+        public abstract object? RawValue { get; }
+
+        /// <summary>
+        /// Attemps to replace the argument value.
+        /// </summary>
+        /// <param name="rawValue">The new raw value to attempt setting.</param>
+        /// <exception cref="ArgumentException">The new value is not compatible with the argument type.</exception>
+        public abstract Argument WithRawValue(object? rawValue);
+
+        /// <summary>
+        /// Checks whether the given <paramref name="value"/> is compatible with 
+        /// the declared <see cref="Parameter"/> type and nullability constraints.
+        /// </summary>
+        protected object? CheckValue(object? value)
+        {
+            var type = Parameter.ParameterType;
+            if (Parameter.ParameterType.IsByRef && Parameter.ParameterType.HasElementType)
+                type = Parameter.ParameterType.GetElementType();
+
+            if (value != null)
+            {
+                if (type.IsAssignableFrom(value.GetType()))
+                    return value;
+                else
+                    throw new ArgumentException(ThisAssembly.Strings.ValueNotCompatible(Parameter.Name, value.GetType().GetFormattedName(), type.GetFormattedName()));
+            }
+
+            // non-value type and Nullable<T> can handle a null return.
+            if (!type.IsValueType ||
+                (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(Nullable<>)))
+                return value;
+
+            throw new ArgumentNullException(nameof(value), ThisAssembly.Strings.ValueTypeIsNull(Parameter.Name, type.GetFormattedName()));
+        }
+    }
+
+    /// <summary>
+    /// A generic object-based argument, useful for cases where the type of the value 
+    /// isn't known at compile-time.
+    /// </summary>
+    public record ObjectArgument : Argument
+    {
+        readonly object? value;
+
+        /// <summary>
+        /// Creates the argument with the given <paramref name="parameter"/> and <paramref name="value"/>.
+        /// </summary>
+        public ObjectArgument(ParameterInfo parameter, object? value)
+            : base(parameter) => this.value = CheckValue(value);
+
+        /// <inheritdoc />
+        public override object? RawValue => value;
+
+        /// <inheritdoc />
+        public override Argument WithRawValue(object? rawValue) => new ObjectArgument(Parameter, CheckValue(rawValue));
+    }
+
+    /// <summary>
+    /// A strong-typed argument, used when the argument type is known at compile-time, 
+    /// which avoids unnecessary value type boxing. Typically created from <see cref="Argument.Create"/> 
+    /// factory method.
+    /// </summary>
+    public record Argument<T> : Argument
+    {
+        readonly T? value;
+
+        /// <summary>
+        /// Creates the argument with the given <paramref name="parameter"/> and <paramref name="value"/>.
+        /// </summary>
+        public Argument(ParameterInfo parameter, T? value)
+            : base(parameter)
+            => Value = value;
+
+        /// <summary>
+        /// Gets the typed value of the argument.
+        /// </summary>
+        public T? Value
+        {
+            get => value;
+            init
+            {
+                var type = Parameter.ParameterType;
+                if (Parameter.ParameterType.IsByRef && Parameter.ParameterType.HasElementType)
+                    type = Parameter.ParameterType.GetElementType();
+
+                if (!type.IsAssignableFrom(typeof(T)))
+                    throw new ArgumentException(ThisAssembly.Strings.TypeNotCompatible(
+                        typeof(T).GetFormattedName(), type.GetFormattedName(), Parameter.Name));
+
+                this.value = value;
+            }
+        }
+
+        /// <inheritdoc />
+        public override object? RawValue => Value;
+
+        /// <summary>
+        /// Gets a new <see cref="Argument{T}"/> with the given <paramref name="value"/>.
+        /// </summary>
+        public Argument<T> WithValue(T? value) => new Argument<T>(Parameter, value);
+
+        /// <inheritdoc />
+        public override Argument WithRawValue(object? rawValue)
+            => rawValue is T value ? new Argument<T>(Parameter, value) : new Argument<T>(Parameter, (T?)CheckValue(rawValue));
+
+        /// <summary>
+        /// Implicitly converts a typed argument to the type of its value.
+        /// </summary>
+        /// <example>
+        /// <code>
+        /// var arg = Argument.Create(parameter, 42);
+        /// // implicit conversion allows direct assignment.
+        /// int value = arg;
+        /// </code>
+        /// </example>
+        public static implicit operator T?(Argument<T> argument) => argument.Value;
+
+        /// <inheritdoc />
+        [ExcludeFromCodeCoverage]
+        [DebuggerNonUserCode]
+        public override string ToString() =>
+            // Render as: [ref|out]? [type] [name]: [value|null]
+            (Parameter.IsOut ? Parameter.ParameterType.GetFormattedName().Replace("ref ", "out ") : Parameter.ParameterType.GetFormattedName()) +
+            " " + Parameter.Name +
+            (": " + Value == null ? "null" :
+                (IsString(Parameter.ParameterType) ? "\"" + Value + "\"" :
+                    // render boolean as lowercase to match C#
+                    (Value is bool b) ? b.ToString().ToLowerInvariant() :
+                    Value)
+            );
+
+        static bool IsString(Type type) => type == typeof(string) ||
+            (type.IsByRef && type.HasElementType && type.GetElementType() == typeof(string));
+    }
+}

--- a/src/Avatar/ArgumentCollection.Create.cs
+++ b/src/Avatar/ArgumentCollection.Create.cs
@@ -1,0 +1,271 @@
+﻿using System.Reflection;
+
+namespace Avatars
+{
+    partial class ArgumentCollection
+    {
+        /// <summary>
+        /// Creates an argument collection with the given parameter(s) and argument value(s).
+        /// </summary>
+        /// <exception cref="TargetParameterCountException">The <paramref name="parameters"/> does not contain 
+        /// the same number of parameters for the given argument(s).</exception>
+        public static ArgumentCollection Create<T>(ParameterInfo[] parameters, T arg)
+            => parameters.Length != 1 ? throw new TargetParameterCountException() : new ArgumentCollection(
+                Argument.Create(parameters[0], arg));
+
+        /// <summary>
+        /// Creates an argument collection with the given parameter(s) and argument value(s).
+        /// </summary>
+        /// <exception cref="TargetParameterCountException">The <paramref name="parameters"/> does not contain 
+        /// the same number of parameters for the given argument(s).</exception>
+        public static ArgumentCollection Create<T1, T2>(ParameterInfo[] parameters, T1 arg1, T2 arg2)
+            => parameters.Length != 2 ? throw new TargetParameterCountException() : new ArgumentCollection(
+                Argument.Create(parameters[0], arg1),
+                Argument.Create(parameters[1], arg2));
+
+        /// <summary>
+        /// Creates an argument collection with the given parameter(s) and argument value(s).
+        /// </summary>
+        /// <exception cref="TargetParameterCountException">The <paramref name="parameters"/> does not contain 
+        /// the same number of parameters for the given argument(s).</exception>
+        public static ArgumentCollection Create<T1, T2, T3>(ParameterInfo[] parameters, T1 arg1, T2 arg2, T3 arg3)
+            => parameters.Length != 3 ? throw new TargetParameterCountException() : new ArgumentCollection(
+                Argument.Create(parameters[0], arg1),
+                Argument.Create(parameters[1], arg2),
+                Argument.Create(parameters[2], arg3));
+
+        /// <summary>
+        /// Creates an argument collection with the given parameter(s) and argument value(s).
+        /// </summary>
+        /// <exception cref="TargetParameterCountException">The <paramref name="parameters"/> does not contain 
+        /// the same number of parameters for the given argument(s).</exception>
+        public static ArgumentCollection Create<T1, T2, T3, T4>(ParameterInfo[] parameters, T1 arg1, T2 arg2, T3 arg3, T4 arg4)
+            => parameters.Length != 4 ? throw new TargetParameterCountException() : new ArgumentCollection(
+                Argument.Create(parameters[0], arg1),
+                Argument.Create(parameters[1], arg2),
+                Argument.Create(parameters[2], arg3),
+                Argument.Create(parameters[3], arg4));
+
+        /// <summary>
+        /// Creates an argument collection with the given parameter(s) and argument value(s).
+        /// </summary>
+        /// <exception cref="TargetParameterCountException">The <paramref name="parameters"/> does not contain 
+        /// the same number of parameters for the given argument(s).</exception>
+        public static ArgumentCollection Create<T1, T2, T3, T4, T5>(ParameterInfo[] parameters, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5)
+            => parameters.Length != 5 ? throw new TargetParameterCountException() : new ArgumentCollection(
+                Argument.Create(parameters[0], arg1),
+                Argument.Create(parameters[1], arg2),
+                Argument.Create(parameters[2], arg3),
+                Argument.Create(parameters[3], arg4),
+                Argument.Create(parameters[4], arg5));
+
+        /// <summary>
+        /// Creates an argument collection with the given parameter(s) and argument value(s).
+        /// </summary>
+        /// <exception cref="TargetParameterCountException">The <paramref name="parameters"/> does not contain 
+        /// the same number of parameters for the given argument(s).</exception>
+        public static ArgumentCollection Create<T1, T2, T3, T4, T5, T6>(ParameterInfo[] parameters, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6)
+            => parameters.Length != 6 ? throw new TargetParameterCountException() : new ArgumentCollection(
+                Argument.Create(parameters[0], arg1),
+                Argument.Create(parameters[1], arg2),
+                Argument.Create(parameters[2], arg3),
+                Argument.Create(parameters[3], arg4),
+                Argument.Create(parameters[4], arg5),
+                Argument.Create(parameters[5], arg6));
+
+        /// <summary>
+        /// Creates an argument collection with the given parameter(s) and argument value(s).
+        /// </summary>
+        /// <exception cref="TargetParameterCountException">The <paramref name="parameters"/> does not contain 
+        /// the same number of parameters for the given argument(s).</exception>
+        public static ArgumentCollection Create<T1, T2, T3, T4, T5, T6, T7>(ParameterInfo[] parameters, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7)
+            => parameters.Length != 7 ? throw new TargetParameterCountException() : new ArgumentCollection(
+                Argument.Create(parameters[0], arg1),
+                Argument.Create(parameters[1], arg2),
+                Argument.Create(parameters[2], arg3),
+                Argument.Create(parameters[3], arg4),
+                Argument.Create(parameters[4], arg5),
+                Argument.Create(parameters[5], arg6),
+                Argument.Create(parameters[6], arg7));
+
+        /// <summary>
+        /// Creates an argument collection with the given parameter(s) and argument value(s).
+        /// </summary>
+        /// <exception cref="TargetParameterCountException">The <paramref name="parameters"/> does not contain 
+        /// the same number of parameters for the given argument(s).</exception>
+        public static ArgumentCollection Create<T1, T2, T3, T4, T5, T6, T7, T8>(ParameterInfo[] parameters, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8)
+            => parameters.Length != 8 ? throw new TargetParameterCountException() : new ArgumentCollection(
+                Argument.Create(parameters[0], arg1),
+                Argument.Create(parameters[1], arg2),
+                Argument.Create(parameters[2], arg3),
+                Argument.Create(parameters[3], arg4),
+                Argument.Create(parameters[4], arg5),
+                Argument.Create(parameters[5], arg6),
+                Argument.Create(parameters[6], arg7),
+                Argument.Create(parameters[7], arg8));
+
+        /// <summary>
+        /// Creates an argument collection with the given parameter(s) and argument value(s).
+        /// </summary>
+        /// <exception cref="TargetParameterCountException">The <paramref name="parameters"/> does not contain 
+        /// the same number of parameters for the given argument(s).</exception>
+        public static ArgumentCollection Create<T1, T2, T3, T4, T5, T6, T7, T8, T9>(ParameterInfo[] parameters, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9)
+            => parameters.Length != 9 ? throw new TargetParameterCountException() : new ArgumentCollection(
+                Argument.Create(parameters[0], arg1),
+                Argument.Create(parameters[1], arg2),
+                Argument.Create(parameters[2], arg3),
+                Argument.Create(parameters[3], arg4),
+                Argument.Create(parameters[4], arg5),
+                Argument.Create(parameters[5], arg6),
+                Argument.Create(parameters[6], arg7),
+                Argument.Create(parameters[7], arg8),
+                Argument.Create(parameters[8], arg9));
+
+        /// <summary>
+        /// Creates an argument collection with the given parameter(s) and argument value(s).
+        /// </summary>
+        /// <exception cref="TargetParameterCountException">The <paramref name="parameters"/> does not contain 
+        /// the same number of parameters for the given argument(s).</exception>
+        public static ArgumentCollection Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(ParameterInfo[] parameters, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10)
+            => parameters.Length != 10 ? throw new TargetParameterCountException() : new ArgumentCollection(
+                Argument.Create(parameters[0], arg1),
+                Argument.Create(parameters[1], arg2),
+                Argument.Create(parameters[2], arg3),
+                Argument.Create(parameters[3], arg4),
+                Argument.Create(parameters[4], arg5),
+                Argument.Create(parameters[5], arg6),
+                Argument.Create(parameters[6], arg7),
+                Argument.Create(parameters[7], arg8),
+                Argument.Create(parameters[8], arg9),
+                Argument.Create(parameters[9], arg10));
+
+        /// <summary>
+        /// Creates an argument collection with the given parameter(s) and argument value(s).
+        /// </summary>
+        /// <exception cref="TargetParameterCountException">The <paramref name="parameters"/> does not contain 
+        /// the same number of parameters for the given argument(s).</exception>
+        public static ArgumentCollection Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(ParameterInfo[] parameters, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11)
+            => parameters.Length != 11 ? throw new TargetParameterCountException() : new ArgumentCollection(
+                Argument.Create(parameters[0], arg1),
+                Argument.Create(parameters[1], arg2),
+                Argument.Create(parameters[2], arg3),
+                Argument.Create(parameters[3], arg4),
+                Argument.Create(parameters[4], arg5),
+                Argument.Create(parameters[5], arg6),
+                Argument.Create(parameters[6], arg7),
+                Argument.Create(parameters[7], arg8),
+                Argument.Create(parameters[8], arg9),
+                Argument.Create(parameters[9], arg10),
+                Argument.Create(parameters[10], arg11));
+
+        /// <summary>
+        /// Creates an argument collection with the given parameter(s) and argument value(s).
+        /// </summary>
+        /// <exception cref="TargetParameterCountException">The <paramref name="parameters"/> does not contain 
+        /// the same number of parameters for the given argument(s).</exception>
+        public static ArgumentCollection Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(ParameterInfo[] parameters, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12)
+            => parameters.Length != 12 ? throw new TargetParameterCountException() : new ArgumentCollection(
+                Argument.Create(parameters[0], arg1),
+                Argument.Create(parameters[1], arg2),
+                Argument.Create(parameters[2], arg3),
+                Argument.Create(parameters[3], arg4),
+                Argument.Create(parameters[4], arg5),
+                Argument.Create(parameters[5], arg6),
+                Argument.Create(parameters[6], arg7),
+                Argument.Create(parameters[7], arg8),
+                Argument.Create(parameters[8], arg9),
+                Argument.Create(parameters[9], arg10),
+                Argument.Create(parameters[10], arg11),
+                Argument.Create(parameters[11], arg12));
+
+        /// <summary>
+        /// Creates an argument collection with the given parameter(s) and argument value(s).
+        /// </summary>
+        /// <exception cref="TargetParameterCountException">The <paramref name="parameters"/> does not contain 
+        /// the same number of parameters for the given argument(s).</exception>
+        public static ArgumentCollection Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(ParameterInfo[] parameters, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13)
+            => parameters.Length != 13 ? throw new TargetParameterCountException() : new ArgumentCollection(
+                Argument.Create(parameters[0], arg1),
+                Argument.Create(parameters[1], arg2),
+                Argument.Create(parameters[2], arg3),
+                Argument.Create(parameters[3], arg4),
+                Argument.Create(parameters[4], arg5),
+                Argument.Create(parameters[5], arg6),
+                Argument.Create(parameters[6], arg7),
+                Argument.Create(parameters[7], arg8),
+                Argument.Create(parameters[8], arg9),
+                Argument.Create(parameters[9], arg10),
+                Argument.Create(parameters[10], arg11),
+                Argument.Create(parameters[11], arg12),
+                Argument.Create(parameters[12], arg13));
+
+        /// <summary>
+        /// Creates an argument collection with the given parameter(s) and argument value(s).
+        /// </summary>
+        /// <exception cref="TargetParameterCountException">The <paramref name="parameters"/> does not contain 
+        /// the same number of parameters for the given argument(s).</exception>
+        public static ArgumentCollection Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(ParameterInfo[] parameters, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14)
+            => parameters.Length != 14 ? throw new TargetParameterCountException() : new ArgumentCollection(
+                Argument.Create(parameters[0], arg1),
+                Argument.Create(parameters[1], arg2),
+                Argument.Create(parameters[2], arg3),
+                Argument.Create(parameters[3], arg4),
+                Argument.Create(parameters[4], arg5),
+                Argument.Create(parameters[5], arg6),
+                Argument.Create(parameters[6], arg7),
+                Argument.Create(parameters[7], arg8),
+                Argument.Create(parameters[8], arg9),
+                Argument.Create(parameters[9], arg10),
+                Argument.Create(parameters[10], arg11),
+                Argument.Create(parameters[11], arg12),
+                Argument.Create(parameters[12], arg13),
+                Argument.Create(parameters[13], arg14));
+
+        /// <summary>
+        /// Creates an argument collection with the given parameter(s) and argument value(s).
+        /// </summary>
+        /// <exception cref="TargetParameterCountException">The <paramref name="parameters"/> does not contain 
+        /// the same number of parameters for the given argument(s).</exception>
+        public static ArgumentCollection Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(ParameterInfo[] parameters, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15)
+            => parameters.Length != 15 ? throw new TargetParameterCountException() : new ArgumentCollection(
+                Argument.Create(parameters[0], arg1),
+                Argument.Create(parameters[1], arg2),
+                Argument.Create(parameters[2], arg3),
+                Argument.Create(parameters[3], arg4),
+                Argument.Create(parameters[4], arg5),
+                Argument.Create(parameters[5], arg6),
+                Argument.Create(parameters[6], arg7),
+                Argument.Create(parameters[7], arg8),
+                Argument.Create(parameters[8], arg9),
+                Argument.Create(parameters[9], arg10),
+                Argument.Create(parameters[10], arg11),
+                Argument.Create(parameters[11], arg12),
+                Argument.Create(parameters[12], arg13),
+                Argument.Create(parameters[13], arg14),
+                Argument.Create(parameters[14], arg15));
+
+        /// <summary>
+        /// Creates an argument collection with the given parameter(s) and argument value(s).
+        /// </summary>
+        /// <exception cref="TargetParameterCountException">The <paramref name="parameters"/> does not contain 
+        /// the same number of parameters for the given argument(s).</exception>
+        public static ArgumentCollection Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(ParameterInfo[] parameters, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15, T16 arg16)
+            => parameters.Length != 16 ? throw new TargetParameterCountException() : new ArgumentCollection(
+                Argument.Create(parameters[0], arg1),
+                Argument.Create(parameters[1], arg2),
+                Argument.Create(parameters[2], arg3),
+                Argument.Create(parameters[3], arg4),
+                Argument.Create(parameters[4], arg5),
+                Argument.Create(parameters[5], arg6),
+                Argument.Create(parameters[6], arg7),
+                Argument.Create(parameters[7], arg8),
+                Argument.Create(parameters[8], arg9),
+                Argument.Create(parameters[9], arg10),
+                Argument.Create(parameters[10], arg11),
+                Argument.Create(parameters[11], arg12),
+                Argument.Create(parameters[12], arg13),
+                Argument.Create(parameters[13], arg14),
+                Argument.Create(parameters[14], arg15),
+                Argument.Create(parameters[15], arg16));
+    }
+}

--- a/src/Avatar/ArgumentCollection.cs
+++ b/src/Avatar/ArgumentCollection.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
@@ -13,117 +14,136 @@ namespace Avatars
     /// Contains the arguments of a method invocation as well as their 
     /// parameter information.
     /// </summary>
-    [DebuggerTypeProxy(typeof(DebugView))]
-    [DebuggerDisplay("Count = {Count}")]
-    public class ArgumentCollection : IArgumentCollection
+    //[DebuggerTypeProxy(typeof(DebugView))]
+    //[DebuggerDisplay("Count = {Count}")]
+    public partial class ArgumentCollection : IArgumentCollection
     {
-        static readonly object NullValue = new object();
-
-        readonly ParameterInfo[] infos;
-        readonly Dictionary<string, ParameterInfo> nameParams;
-        // TODO: should we provide box-free holders too?
-        readonly Dictionary<string, object?> values = new();
+        readonly Dictionary<string, Argument> arguments;
 
         /// <summary>
-        /// Creates a new argument collection by cloning the given <see cref="IArgumentCollection"/> 
-        /// and optionally specifying new values.
+        /// Creates a new argument collection.
         /// </summary>
-        /// <remarks>
-        /// If the received <paramref name="arguments"/> is an instance of <see cref="ArgumentCollection"/>, 
-        /// the existing values will be copied over too.
-        /// </remarks>
-        public ArgumentCollection(IArgumentCollection arguments, params object?[] values)
-        {
-            if (arguments is ArgumentCollection collection)
-            {
-                infos = collection.infos;
-                nameParams = collection.nameParams;
-                this.values = collection.values;
-            }
-            else
-            {
-                infos = arguments.ToArray();
-                nameParams = infos.ToDictionary(x => x.Name);
-            }
-
-            SetValues(values);
-        }
+        public ArgumentCollection(params Argument[] arguments)
+            : this(arguments.ToDictionary(x => x.Parameter.Name), arguments.Select(x => x.Parameter).ToArray())
+        { }
 
         /// <summary>
-        /// Creates a new argument collection using the given parameter information 
-        /// and optional values.
+        /// Creates a new argument collection with the given parameters, where the 
+        /// argument values are provided using object initializer syntax.
         /// </summary>
-        public ArgumentCollection(ParameterInfo[] infos, params object?[] values)
-        {
-            this.infos = infos;
-            nameParams = infos.ToDictionary(x => x.Name);
-            SetValues(values);
-        }
+        /// <example>
+        /// This constructor overload, in combination with the <see cref="Add{T}(string, T)"/> and 
+        /// <see cref="Add{T}(int, T)"/> methods, enables the following usage:
+        /// <c>
+        /// var args = new ArgumentCollection(method.GetParameters())
+        /// {
+        ///   { "foo", "bar" },
+        ///   { "value", 23 },
+        ///   { "enabled", true }
+        /// };
+        /// </c>
+        /// This is an alternative to the <c>ArgumentCollection.Create</c> factory methods that 
+        /// might be more intuitive or appropriate depending on the needs (i.e. compile-time 
+        /// code generation uses this syntax).
+        /// </example>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public ArgumentCollection(ParameterInfo[] parameters)
+            : this(new Dictionary<string, Argument>(), parameters)
+        { }
+
+        ArgumentCollection(Dictionary<string, Argument> arguments, ParameterInfo[] parameters)
+            => (this.arguments, Parameters)
+            = (arguments, parameters);
+
+        /// <summary>
+        /// The <see cref="ParameterInfo"/> definitions for all arguments in the collection.
+        /// </summary>
+        public ParameterInfo[] Parameters { get; }
 
         /// <inheritdoc />
-        public ParameterInfo this[int index]
-        {
-            get => (index < 0 || index >= infos.Length)
+        public int Count => Parameters.Length;
+
+        /// <inheritdoc />
+        public bool Contains(string name) => arguments.ContainsKey(name);
+
+        /// <inheritdoc />
+        public Argument this[int index] => (index < 0 || index >= Parameters.Length)
                 ? throw new IndexOutOfRangeException(ThisAssembly.Strings.ArgumentIndexNotFound(index))
-                : infos[index];
-        }
+                : arguments.TryGetValue(Parameters[index].Name, out var argument)
+                ? argument
+                : throw new KeyNotFoundException(ThisAssembly.Strings.ArgumentNotFound(Parameters[index].Name));
 
         /// <inheritdoc />
-        public ParameterInfo this[string name]
+        public Argument this[string name]
         {
-            get => nameParams.TryGetValue(name, out var parameter)
-                ? parameter
+            get => arguments.TryGetValue(name, out var argument)
+                ? argument
                 : throw new KeyNotFoundException(ThisAssembly.Strings.ArgumentNotFound(name));
-        }
-
-        /// <inheritdoc />
-        public int Count => infos.Length;
-
-        /// <inheritdoc />
-        public object? GetValue(string name)
-        {
-            if (!nameParams.ContainsKey(name))
-                throw new KeyNotFoundException(ThisAssembly.Strings.ArgumentNotFound(name));
-
-            return values.TryGetValue(name, out var value) ? value : null;
-        }
-
-        /// <inheritdoc />
-        public object? GetValue(int index)
-        {
-            if (index < 0 || index >= infos.Length)
-                throw new IndexOutOfRangeException(ThisAssembly.Strings.ArgumentIndexNotFound(index));
-
-            return values.TryGetValue(infos[index].Name, out var value) ? value : null;
-        }
-
-        /// <inheritdoc />
-        public void SetValue(string name, object? value)
-        {
-            if (!nameParams.ContainsKey(name))
-                throw new KeyNotFoundException(ThisAssembly.Strings.ArgumentNotFound(name));
-
-            values[name] = value;
-        }
-
-        /// <inheritdoc />
-        public void SetValue(int index, object? value)
-        {
-            if (index < 0 || index >= infos.Length)
-                throw new IndexOutOfRangeException(ThisAssembly.Strings.ArgumentIndexNotFound(index));
-
-            SetValue(infos[index].Name, value);
+            set => arguments[name] = value;
         }
 
         /// <summary>
-        /// Sets the value of the parameter with the given name.
+        /// Gets the value of the argument with the given name.
+        /// </summary>
+        /// <param name="name">Name of the argument to retrieve.</param>
+        /// <returns>The <see cref="Argument.RawValue"/>.</returns>
+        /// <exception cref="KeyNotFoundException">The collection does not contain an argument value with the given name.</exception>
+        public object? GetValue(string name) => arguments.TryGetValue(name, out var argument)
+            ? argument.RawValue
+            : throw new KeyNotFoundException(ThisAssembly.Strings.ArgumentNotFound(name));
+
+        /// <summary>
+        /// Gets the value of the argument at the given index.
+        /// </summary>
+        /// <param name="index">Index of argument to retrieve.</param>
+        /// <returns>The <see cref="Argument.RawValue"/>.</returns>
+        /// <exception cref="IndexOutOfRangeException">The index is outside of the bounds of <see cref="Parameters"/>.</exception>
+        public object? GetValue(int index) => GetValue(Parameters[index].Name);
+
+        /// <summary>
+        /// Sets the raw value of the argument with the given name.
+        /// </summary>
+        /// <param name="name">Name of the argument to assign.</param>
+        /// <param name="value">The value of the argument, which must be compatible with the 
+        /// corresponding <see cref="ParameterInfo"/> from <see cref="Parameters"/>.</param>
+        /// <returns>The <see cref="Argument.RawValue"/>.</returns>
+        /// <exception cref="KeyNotFoundException">The collection does not contain an argument value with the given name.</exception>
+        public IArgumentCollection SetValue(string name, object? value)
+        {
+            if (!arguments.TryGetValue(name, out var argument))
+                throw new KeyNotFoundException(ThisAssembly.Strings.ArgumentNotFound(name));
+
+            arguments[name] = argument.WithRawValue(value);
+
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the value of the argument at the given index.
+        /// </summary>
+        /// <param name="index">Index of argument to assign.</param>
+        /// <param name="value">The value of the argument, which must be compatible with the 
+        /// corresponding <see cref="ParameterInfo"/> from <see cref="Parameters"/>.</param>
+        /// <returns>The <see cref="Argument.RawValue"/>.</returns>
+        /// <exception cref="IndexOutOfRangeException">The index is outside of the bounds of <see cref="Parameters"/>.</exception>
+        public IArgumentCollection SetValue(int index, object? value)
+        {
+            if (index < 0 || index >= Parameters.Length)
+                throw new IndexOutOfRangeException(ThisAssembly.Strings.ArgumentIndexNotFound(index));
+
+            return SetValue(Parameters[index].Name, value);
+        }
+
+        /// <summary>
+        /// Sets (or adds) the value of the parameter with the given name.
         /// </summary>
         /// <typeparam name="T">Type of the value being set.</typeparam>
         /// <param name="name">Name of the argument being set.</param>
         /// <param name="value">Value of the argument.</param>
         /// <remarks>
-        /// This method is equivalent to <see cref="SetValue(string, object?)"/> and 
-        /// supports object initialization syntax so you can write code like:
+        /// This method is similar to <see cref="SetValue(int, object?)"/> but 
+        /// can also add values to parameters which haven't been assigned a value 
+        /// yet, and supports object initialization syntax so you can write code like:
         /// <code>
         /// var args = new ArgumentCollection(parameters) 
         /// {
@@ -133,7 +153,27 @@ namespace Avatars
         /// };
         /// </code>
         /// </remarks>
-        public void Add<T>(string name, T? value) => SetValue(name, value);
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public void Add<T>(string name, T? value)
+        {
+            if (!arguments.TryGetValue(name, out var argument))
+            {
+                var parameter = Parameters.FirstOrDefault(p => p.Name == name);
+                if (parameter == null)
+                    throw new KeyNotFoundException(ThisAssembly.Strings.ArgumentNotFound(name));
+
+                argument = Argument.Create(parameter, value);
+                arguments[name] = argument;
+            }
+            else
+            {
+                // Avoid boxing whenever possible.
+                if (argument is Argument<T> typed)
+                    arguments[name] = typed.WithValue(value);
+                else
+                    arguments[name] = argument.WithRawValue(value);
+            }
+        }
 
         /// <summary>
         /// Sets the value of the parameter with the given index.
@@ -153,15 +193,16 @@ namespace Avatars
         /// };
         /// </code>
         /// </remarks>
-        public void Add<T>(int index, T? value) => SetValue(index, value);
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public void Add<T>(int index, T? value) => Add(Parameters[index].Name, value);
 
         /// <inheritdoc />
-        public IEnumerator<ParameterInfo> GetEnumerator() => nameParams.Values.GetEnumerator();
+        public IEnumerator<Argument> GetEnumerator() => arguments.Values.GetEnumerator();
 
         /// <inheritdoc />
         [DebuggerNonUserCode]
         [ExcludeFromCodeCoverage]
-        public override string ToString() => string.Join(", ", infos.Select(ToString));
+        public override string ToString() => string.Join(", ", Parameters.Select(ToString));
 
         [ExcludeFromCodeCoverage]
         [DebuggerNonUserCode]
@@ -169,49 +210,27 @@ namespace Avatars
             (parameter.IsOut ? parameter.ParameterType.GetFormattedName().Replace("ref ", "out ") : parameter.ParameterType.GetFormattedName()) +
             " " + parameter.Name +
             (parameter.IsOut ? "" :
-                (": " + (!values.TryGetValue(parameter.Name, out var value) ? "null" :
-                    ((IsString(parameter.ParameterType) && value != null) ? "\"" + value + "\"" :
+                (": " + (!arguments.TryGetValue(parameter.Name, out var argument) ? "null" :
+                    ((IsString(parameter.ParameterType) && argument.RawValue != null) ? "\"" + argument.RawValue + "\"" :
                         // render boolean as lowercase to match C#
-                        (value is bool b) ? b.ToString().ToLowerInvariant() :
-                        value ?? "null"))
+                        (argument.RawValue is bool b) ? b.ToString().ToLowerInvariant() :
+                        argument.RawValue ?? "null"))
                 )
             );
-
-        void SetValues(object?[] values)
-        {
-            if (values != null && values.Length > 0)
-            {
-                if (values.Length != infos.Length)
-                    throw new ArgumentException(ThisAssembly.Strings.ArgumentsMismatch);
-
-                for (var i = 0; i < values.Length; i++)
-                {
-                    this.values[infos[i].Name] = values[i];
-                }
-            }
-        }
 
         static bool IsString(Type type) => type == typeof(string) ||
             (type.IsByRef && type.HasElementType && type.GetElementType() == typeof(string));
 
         /// <inheritdoc />
         public override bool Equals(object obj)
-        {
-            return obj is ArgumentCollection collection &&
-                infos.SequenceEqual(collection.infos) &&
-                values.Count == collection.Count &&
-                values.Values.SequenceEqual(collection.values.Values);
-        }
+            => obj is IArgumentCollection collection && this.SequenceEqual(collection);
 
         /// <inheritdoc />
         public override int GetHashCode()
         {
             var hash = new HashCode();
-            foreach (var prm in infos)
-                hash.Add(prm);
-
-            foreach (var arg in values.Values)
-                hash.Add(arg ?? NullValue);
+            foreach (var arg in arguments.Values)
+                hash.Add(arg);
 
             return hash.ToHashCode();
         }
@@ -226,7 +245,7 @@ namespace Avatars
             public DebugView(ArgumentCollection arguments) => this.arguments = arguments;
 
             [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
-            public KeyValuePair<ParameterInfo, object?>[] Items => arguments.infos
+            public KeyValuePair<ParameterInfo, object?>[] Items => arguments.Parameters
                 // TODO: get value display, not the actual value??
                 .Select(info => new KeyValuePair<ParameterInfo, object?>(info, arguments.GetValue(info.Name)))
                 .ToArray();

--- a/src/Avatar/IArgumentCollection.cs
+++ b/src/Avatar/IArgumentCollection.cs
@@ -1,17 +1,17 @@
 ﻿using System.Collections.Generic;
-using System.Reflection;
 
 namespace Avatars
 {
     /// <summary>
     /// Represents the arguments of a method invocation.
     /// </summary>
-    public interface IArgumentCollection : IReadOnlyList<ParameterInfo>
+    public interface IArgumentCollection : IReadOnlyList<Argument>
     {
         /// <summary>
-        /// Gets the <see cref="ParameterInfo"/> with the given name.
+        /// Determines whether the collection contains an argument with the given name.
         /// </summary>
-        ParameterInfo this[string name] { get; }
+        /// <param name="name">The argument name to lookup.</param>
+        public bool Contains(string name);
 
         /// <summary>
         /// Gets the (reference or boxed) value for the argument with the 
@@ -29,12 +29,17 @@ namespace Avatars
         /// Sets the (reference or boxed) value for the argument with the 
         /// given name.
         /// </summary>
-        public void SetValue(string name, object? value);
+        public IArgumentCollection SetValue(string name, object? value);
 
         /// <summary>
         /// Sets the (reference or boxed) value for the argument with the 
         /// given index.
         /// </summary>
-        public void SetValue(int index, object? value);
+        public IArgumentCollection SetValue(int index, object? value);
+
+        /// <summary>
+        /// Gets or sets the argument with the given name.
+        /// </summary>
+        public Argument this[string name] { get; set; }
     }
 }

--- a/src/Avatar/IMethodInvocation.cs
+++ b/src/Avatar/IMethodInvocation.cs
@@ -60,10 +60,9 @@ namespace Avatars
         /// values.
         /// </summary>
         /// <param name="returnValue">Optional return value from the method invocation. <see langword="null"/> for <see langword="void"/> methods.</param>
-        /// <param name="arguments">Ordered list of all arguments to the method invocation, including ref/out arguments.
-        /// If not provided, the arguments from the current invocation will be used.</param>
+        /// <param name="arguments">Ordered list of all arguments to the method invocation, including ref/out arguments.</param>
         /// <returns>The <see cref="IMethodReturn"/> for the current invocation.</returns>
-        IMethodReturn CreateValueReturn(object? returnValue, IArgumentCollection? arguments = null);
+        IMethodReturn CreateValueReturn(object? returnValue, IArgumentCollection arguments);
 
         /// <summary>
         /// Creates a method invocation return that represents 

--- a/src/Avatar/MethodInvocation.Create.cs
+++ b/src/Avatar/MethodInvocation.Create.cs
@@ -1,0 +1,229 @@
+﻿using System.Reflection;
+
+namespace Avatars
+{
+    partial class MethodInvocation
+    {
+        #region Create(object, MethodBase, args)
+
+        /// <summary>
+        /// Creates a method invocation that has no arguments.
+        /// </summary>
+        /// <param name="target">The target of the invocation.</param>
+        /// <param name="method">The method being invoked.</param>
+        public static MethodInvocation Create(object target, MethodBase method) => new MethodInvocation(target, method);
+
+        /// <summary>
+        /// Creates a method invocation with the given typed argument value.
+        /// </summary>
+        /// <param name="target">The target of the invocation.</param>
+        /// <param name="method">The method being invoked.</param>
+        /// <param name="arg">The argument value</param>
+        public static MethodInvocation Create<T>(object target, MethodBase method, T arg)
+            => new MethodInvocation(target, method, ArgumentCollection.Create(method.GetParameters(), arg));
+
+        /// <summary>
+        /// Creates a method invocation with the given typed argument values.
+        /// </summary>
+        public static MethodInvocation Create<T1, T2>(object target, MethodBase method, T1 arg1, T2 arg2)
+            => new MethodInvocation(target, method, ArgumentCollection.Create(method.GetParameters(), arg1, arg2));
+
+        /// <summary>
+        /// Creates a method invocation with the given typed argument values.
+        /// </summary>
+        public static MethodInvocation Create<T1, T2, T3>(object target, MethodBase method, T1 arg1, T2 arg2, T3 arg3)
+            => new MethodInvocation(target, method, ArgumentCollection.Create(method.GetParameters(), arg1, arg2, arg3));
+
+        /// <summary>
+        /// Creates a method invocation with the given typed argument values.
+        /// </summary>
+        public static MethodInvocation Create<T1, T2, T3, T4>(object target, MethodBase method, T1 arg1, T2 arg2, T3 arg3, T4 arg4)
+            => new MethodInvocation(target, method, ArgumentCollection.Create(method.GetParameters(), arg1, arg2, arg3, arg4));
+
+        /// <summary>
+        /// Creates a method invocation with the given typed argument values.
+        /// </summary>
+        public static MethodInvocation Create<T1, T2, T3, T4, T5>(object target, MethodBase method, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5)
+            => new MethodInvocation(target, method, ArgumentCollection.Create(method.GetParameters(), arg1, arg2, arg3, arg4, arg5));
+
+        /// <summary>
+        /// Creates a method invocation with the given typed argument values.
+        /// </summary>
+        public static MethodInvocation Create<T1, T2, T3, T4, T5, T6>(object target, MethodBase method, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6)
+            => new MethodInvocation(target, method, ArgumentCollection.Create(method.GetParameters(), arg1, arg2, arg3, arg4, arg5, arg6));
+
+        /// <summary>
+        /// Creates a method invocation with the given typed argument values.
+        /// </summary>
+        public static MethodInvocation Create<T1, T2, T3, T4, T5, T6, T7>(object target, MethodBase method, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7)
+            => new MethodInvocation(target, method, ArgumentCollection.Create(method.GetParameters(), arg1, arg2, arg3, arg4, arg5, arg6, arg7));
+
+        /// <summary>
+        /// Creates a method invocation with the given typed argument values.
+        /// </summary>
+        public static MethodInvocation Create<T1, T2, T3, T4, T5, T6, T7, T8>(object target, MethodBase method, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8)
+            => new MethodInvocation(target, method, ArgumentCollection.Create(method.GetParameters(), arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8));
+
+        /// <summary>
+        /// Creates a method invocation with the given typed argument values.
+        /// </summary>
+        public static MethodInvocation Create<T1, T2, T3, T4, T5, T6, T7, T8, T9>(object target, MethodBase method, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9)
+            => new MethodInvocation(target, method, ArgumentCollection.Create(method.GetParameters(), arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9));
+
+        /// <summary>
+        /// Creates a method invocation with the given typed argument values.
+        /// </summary>
+        public static MethodInvocation Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(object target, MethodBase method, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10)
+            => new MethodInvocation(target, method, ArgumentCollection.Create(method.GetParameters(), arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10));
+
+        /// <summary>
+        /// Creates a method invocation with the given typed argument values.
+        /// </summary>
+        public static MethodInvocation Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(object target, MethodBase method, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11)
+            => new MethodInvocation(target, method, ArgumentCollection.Create(method.GetParameters(), arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11));
+
+        /// <summary>
+        /// Creates a method invocation with the given typed argument values.
+        /// </summary>
+        public static MethodInvocation Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(object target, MethodBase method, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12)
+            => new MethodInvocation(target, method, ArgumentCollection.Create(method.GetParameters(), arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12));
+
+        /// <summary>
+        /// Creates a method invocation with the given typed argument values.
+        /// </summary>
+        public static MethodInvocation Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(object target, MethodBase method, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13)
+            => new MethodInvocation(target, method, ArgumentCollection.Create(method.GetParameters(), arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13));
+
+        /// <summary>
+        /// Creates a method invocation with the given typed argument values.
+        /// </summary>
+        public static MethodInvocation Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(object target, MethodBase method, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14)
+            => new MethodInvocation(target, method, ArgumentCollection.Create(method.GetParameters(), arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14));
+
+        /// <summary>
+        /// Creates a method invocation with the given typed argument values.
+        /// </summary>
+        public static MethodInvocation Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(object target, MethodBase method, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15)
+            => new MethodInvocation(target, method, ArgumentCollection.Create(method.GetParameters(), arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15));
+
+        /// <summary>
+        /// Creates a method invocation with the given typed argument values.
+        /// </summary>
+        public static MethodInvocation Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(object target, MethodBase method, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15, T16 arg16)
+            => new MethodInvocation(target, method, ArgumentCollection.Create(method.GetParameters(), arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16));
+
+        #endregion
+
+        #region Create(object, MethodBase, ExecuteDelegate, args)
+
+        /// <summary>
+        /// Creates a method invocation that has no arguments.
+        /// </summary>
+        /// <param name="target">The target of the invocation.</param>
+        /// <param name="method">The method being invoked.</param>
+        /// <param name="callBase">Delegate to invoke the base method implementation for virtual methods.</param>
+        public static MethodInvocation Create(object target, MethodBase method, ExecuteDelegate callBase) => new MethodInvocation(target, method, callBase, new ArgumentCollection());
+
+        /// <summary>
+        /// Creates a method invocation with the given typed argument value.
+        /// </summary>
+        /// <param name="target">The target of the invocation.</param>
+        /// <param name="method">The method being invoked.</param>
+        /// <param name="callBase">Delegate to invoke the base method implementation for virtual methods.</param>
+        /// <param name="arg">The argument value.</param>
+        public static MethodInvocation Create<T>(object target, MethodBase method, ExecuteDelegate callBase, T arg)
+            => new MethodInvocation(target, method, callBase, ArgumentCollection.Create(method.GetParameters(), arg));
+
+        /// <summary>
+        /// Creates a method invocation with the given typed argument values.
+        /// </summary>
+        public static MethodInvocation Create<T1, T2>(object target, MethodBase method, ExecuteDelegate callBase, T1 arg1, T2 arg2)
+            => new MethodInvocation(target, method, callBase, ArgumentCollection.Create(method.GetParameters(), arg1, arg2));
+
+        /// <summary>
+        /// Creates a method invocation with the given typed argument values.
+        /// </summary>
+        public static MethodInvocation Create<T1, T2, T3>(object target, MethodBase method, ExecuteDelegate callBase, T1 arg1, T2 arg2, T3 arg3)
+            => new MethodInvocation(target, method, callBase, ArgumentCollection.Create(method.GetParameters(), arg1, arg2, arg3));
+
+        /// <summary>
+        /// Creates a method invocation with the given typed argument values.
+        /// </summary>
+        public static MethodInvocation Create<T1, T2, T3, T4>(object target, MethodBase method, ExecuteDelegate callBase, T1 arg1, T2 arg2, T3 arg3, T4 arg4)
+            => new MethodInvocation(target, method, callBase, ArgumentCollection.Create(method.GetParameters(), arg1, arg2, arg3, arg4));
+
+        /// <summary>
+        /// Creates a method invocation with the given typed argument values.
+        /// </summary>
+        public static MethodInvocation Create<T1, T2, T3, T4, T5>(object target, MethodBase method, ExecuteDelegate callBase, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5)
+            => new MethodInvocation(target, method, callBase, ArgumentCollection.Create(method.GetParameters(), arg1, arg2, arg3, arg4, arg5));
+
+        /// <summary>
+        /// Creates a method invocation with the given typed argument values.
+        /// </summary>
+        public static MethodInvocation Create<T1, T2, T3, T4, T5, T6>(object target, MethodBase method, ExecuteDelegate callBase, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6)
+            => new MethodInvocation(target, method, callBase, ArgumentCollection.Create(method.GetParameters(), arg1, arg2, arg3, arg4, arg5, arg6));
+
+        /// <summary>
+        /// Creates a method invocation with the given typed argument values.
+        /// </summary>
+        public static MethodInvocation Create<T1, T2, T3, T4, T5, T6, T7>(object target, MethodBase method, ExecuteDelegate callBase, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7)
+            => new MethodInvocation(target, method, callBase, ArgumentCollection.Create(method.GetParameters(), arg1, arg2, arg3, arg4, arg5, arg6, arg7));
+
+        /// <summary>
+        /// Creates a method invocation with the given typed argument values.
+        /// </summary>
+        public static MethodInvocation Create<T1, T2, T3, T4, T5, T6, T7, T8>(object target, MethodBase method, ExecuteDelegate callBase, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8)
+            => new MethodInvocation(target, method, callBase, ArgumentCollection.Create(method.GetParameters(), arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8));
+
+        /// <summary>
+        /// Creates a method invocation with the given typed argument values.
+        /// </summary>
+        public static MethodInvocation Create<T1, T2, T3, T4, T5, T6, T7, T8, T9>(object target, MethodBase method, ExecuteDelegate callBase, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9)
+            => new MethodInvocation(target, method, callBase, ArgumentCollection.Create(method.GetParameters(), arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9));
+
+        /// <summary>
+        /// Creates a method invocation with the given typed argument values.
+        /// </summary>
+        public static MethodInvocation Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(object target, MethodBase method, ExecuteDelegate callBase, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10)
+            => new MethodInvocation(target, method, callBase, ArgumentCollection.Create(method.GetParameters(), arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10));
+
+        /// <summary>
+        /// Creates a method invocation with the given typed argument values.
+        /// </summary>
+        public static MethodInvocation Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(object target, MethodBase method, ExecuteDelegate callBase, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11)
+            => new MethodInvocation(target, method, callBase, ArgumentCollection.Create(method.GetParameters(), arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11));
+
+        /// <summary>
+        /// Creates a method invocation with the given typed argument values.
+        /// </summary>
+        public static MethodInvocation Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(object target, MethodBase method, ExecuteDelegate callBase, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12)
+            => new MethodInvocation(target, method, callBase, ArgumentCollection.Create(method.GetParameters(), arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12));
+
+        /// <summary>
+        /// Creates a method invocation with the given typed argument values.
+        /// </summary>
+        public static MethodInvocation Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(object target, MethodBase method, ExecuteDelegate callBase, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13)
+            => new MethodInvocation(target, method, callBase, ArgumentCollection.Create(method.GetParameters(), arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13));
+
+        /// <summary>
+        /// Creates a method invocation with the given typed argument values.
+        /// </summary>
+        public static MethodInvocation Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(object target, MethodBase method, ExecuteDelegate callBase, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14)
+            => new MethodInvocation(target, method, callBase, ArgumentCollection.Create(method.GetParameters(), arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14));
+
+        /// <summary>
+        /// Creates a method invocation with the given typed argument values.
+        /// </summary>
+        public static MethodInvocation Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(object target, MethodBase method, ExecuteDelegate callBase, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15)
+            => new MethodInvocation(target, method, callBase, ArgumentCollection.Create(method.GetParameters(), arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15));
+
+        /// <summary>
+        /// Creates a method invocation with the given typed argument values.
+        /// </summary>
+        public static MethodInvocation Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(object target, MethodBase method, ExecuteDelegate callBase, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15, T16 arg16)
+            => new MethodInvocation(target, method, callBase, ArgumentCollection.Create(method.GetParameters(), arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16));
+
+        #endregion
+    }
+}

--- a/src/Avatar/MethodInvocationExtensions.cs
+++ b/src/Avatar/MethodInvocationExtensions.cs
@@ -9,21 +9,214 @@ namespace Avatars
     public static class MethodInvocationExtensions
     {
         /// <summary>
-        /// Creates the method invocation return that ends the 
-        /// current invocation.
-        /// </summary>
-        /// <param name="invocation">The invocation to create the value return for.</param>
-        /// <param name="returnValue">Optional return value from the method invocation. <see langword="null"/> for <see langword="void"/> methods.</param>
-        /// <param name="arguments">Ordered list of all arguments to the method invocation, including ref/out arguments.</param>
-        /// <returns>The <see cref="IMethodReturn"/> for the current invocation.</returns>
-        public static IMethodReturn CreateValueReturn(this IMethodInvocation invocation, object? returnValue, params object?[] arguments)
-            => invocation.CreateValueReturn(returnValue, new ArgumentCollection(invocation.Arguments, arguments));
-
-        /// <summary>
-        /// Adds a behavior in the pipeline that should be skipped during this invocation 
-        /// to the <see cref="IMethodInvocation.SkipBehaviors"/> list.
+        /// Registers a behavior in the pipeline that should be skipped during this invocation 
+        /// by adding it to the <see cref="IMethodInvocation.SkipBehaviors"/> list.
         /// </summary>
         public static void SkipBehavior<TBehavior>(this IMethodInvocation invocation)
             => invocation.SkipBehaviors.Add(typeof(TBehavior));
+
+        /// <summary>
+        /// Creates the method invocation return that ends the current invocation.
+        /// </summary>
+        public static IMethodReturn CreateReturn(this IMethodInvocation invocation)
+            => invocation.CreateValueReturn(null, invocation.Arguments);
+
+        /// <summary>
+        /// Creates the method invocation return that ends the current invocation.
+        /// </summary>
+        public static IMethodReturn CreateReturn<T>(this IMethodInvocation invocation, T arg)
+            => invocation.CreateValueReturn(null, ArgumentCollection.Create(invocation.MethodBase.GetParameters(), arg));
+
+        /// <summary>
+        /// Creates the method invocation return that ends the current invocation.
+        /// </summary>
+        public static IMethodReturn CreateReturn<T1, T2>(this IMethodInvocation invocation, T1 arg1, T2 arg2)
+            => invocation.CreateValueReturn(null, ArgumentCollection.Create(invocation.MethodBase.GetParameters(), arg1, arg2));
+
+        /// <summary>
+        /// Creates the method invocation return that ends the current invocation.
+        /// </summary>
+        public static IMethodReturn CreateReturn<T1, T2, T3>(this IMethodInvocation invocation, T1 arg1, T2 arg2, T3 arg3)
+            => invocation.CreateValueReturn(null, ArgumentCollection.Create(invocation.MethodBase.GetParameters(), arg1, arg2, arg3));
+
+        /// <summary>
+        /// Creates the method invocation return that ends the current invocation.
+        /// </summary>
+        public static IMethodReturn CreateReturn<T1, T2, T3, T4>(this IMethodInvocation invocation, T1 arg1, T2 arg2, T3 arg3, T4 arg4)
+            => invocation.CreateValueReturn(null, ArgumentCollection.Create(invocation.MethodBase.GetParameters(), arg1, arg2, arg3, arg4));
+
+        /// <summary>
+        /// Creates the method invocation return that ends the current invocation.
+        /// </summary>
+        public static IMethodReturn CreateReturn<T1, T2, T3, T4, T5>(this IMethodInvocation invocation, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5)
+            => invocation.CreateValueReturn(null, ArgumentCollection.Create(invocation.MethodBase.GetParameters(), arg1, arg2, arg3, arg4, arg5));
+
+        /// <summary>
+        /// Creates the method invocation return that ends the current invocation.
+        /// </summary>
+        public static IMethodReturn CreateReturn<T1, T2, T3, T4, T5, T6>(this IMethodInvocation invocation, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6)
+            => invocation.CreateValueReturn(null, ArgumentCollection.Create(invocation.MethodBase.GetParameters(), arg1, arg2, arg3, arg4, arg5, arg6));
+
+        /// <summary>
+        /// Creates the method invocation return that ends the current invocation.
+        /// </summary>
+        public static IMethodReturn CreateReturn<T1, T2, T3, T4, T5, T6, T7>(this IMethodInvocation invocation, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7)
+            => invocation.CreateValueReturn(null, ArgumentCollection.Create(invocation.MethodBase.GetParameters(), arg1, arg2, arg3, arg4, arg5, arg6, arg7));
+
+        /// <summary>
+        /// Creates the method invocation return that ends the current invocation.
+        /// </summary>
+        public static IMethodReturn CreateReturn<T1, T2, T3, T4, T5, T6, T7, T8>(this IMethodInvocation invocation, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8)
+            => invocation.CreateValueReturn(null, ArgumentCollection.Create(invocation.MethodBase.GetParameters(), arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8));
+
+        /// <summary>
+        /// Creates the method invocation return that ends the current invocation.
+        /// </summary>
+        public static IMethodReturn CreateReturn<T1, T2, T3, T4, T5, T6, T7, T8, T9>(this IMethodInvocation invocation, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9)
+            => invocation.CreateValueReturn(null, ArgumentCollection.Create(invocation.MethodBase.GetParameters(), arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9));
+
+        /// <summary>
+        /// Creates the method invocation return that ends the current invocation.
+        /// </summary>
+        public static IMethodReturn CreateReturn<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(this IMethodInvocation invocation, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10)
+            => invocation.CreateValueReturn(null, ArgumentCollection.Create(invocation.MethodBase.GetParameters(), arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10));
+
+        /// <summary>
+        /// Creates the method invocation return that ends the current invocation.
+        /// </summary>
+        public static IMethodReturn CreateReturn<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(this IMethodInvocation invocation, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11)
+            => invocation.CreateValueReturn(null, ArgumentCollection.Create(invocation.MethodBase.GetParameters(), arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11));
+
+        /// <summary>
+        /// Creates the method invocation return that ends the current invocation.
+        /// </summary>
+        public static IMethodReturn CreateReturn<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(this IMethodInvocation invocation, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12)
+            => invocation.CreateValueReturn(null, ArgumentCollection.Create(invocation.MethodBase.GetParameters(), arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12));
+
+        /// <summary>
+        /// Creates the method invocation return that ends the current invocation.
+        /// </summary>
+        public static IMethodReturn CreateReturn<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(this IMethodInvocation invocation, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13)
+            => invocation.CreateValueReturn(null, ArgumentCollection.Create(invocation.MethodBase.GetParameters(), arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13));
+
+        /// <summary>
+        /// Creates the method invocation return that ends the current invocation.
+        /// </summary>
+        public static IMethodReturn CreateReturn<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(this IMethodInvocation invocation, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14)
+            => invocation.CreateValueReturn(null, ArgumentCollection.Create(invocation.MethodBase.GetParameters(), arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14));
+
+        /// <summary>
+        /// Creates the method invocation return that ends the current invocation.
+        /// </summary>
+        public static IMethodReturn CreateReturn<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(this IMethodInvocation invocation, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15)
+            => invocation.CreateValueReturn(null, ArgumentCollection.Create(invocation.MethodBase.GetParameters(), arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15));
+
+        /// <summary>
+        /// Creates the method invocation return that ends the current invocation.
+        /// </summary>
+        public static IMethodReturn CreateReturn<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(this IMethodInvocation invocation, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15, T16 arg16)
+            => invocation.CreateValueReturn(null, ArgumentCollection.Create(invocation.MethodBase.GetParameters(), arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16));
+
+        /// <summary>
+        /// Creates the method invocation return that ends the current invocation for a non-void method.
+        /// </summary>
+        public static IMethodReturn CreateValueReturn<TResult>(this IMethodInvocation invocation, TResult result)
+            => invocation.CreateValueReturn(result, invocation.Arguments);
+
+        /// <summary>
+        /// Creates the method invocation return that ends the current invocation for a non-void method.
+        /// </summary>
+        public static IMethodReturn CreateValueReturn<TResult, T>(this IMethodInvocation invocation, TResult result, T arg)
+            => invocation.CreateValueReturn(result, ArgumentCollection.Create(invocation.MethodBase.GetParameters(), arg));
+
+        /// <summary>
+        /// Creates the method invocation return that ends the current invocation for a non-void method.
+        /// </summary>
+        public static IMethodReturn CreateValueReturn<TResult, T1, T2>(this IMethodInvocation invocation, TResult result, T1 arg1, T2 arg2)
+            => invocation.CreateValueReturn(result, ArgumentCollection.Create(invocation.MethodBase.GetParameters(), arg1, arg2));
+
+        /// <summary>
+        /// Creates the method invocation return that ends the current invocation for a non-void method.
+        /// </summary>
+        public static IMethodReturn CreateValueReturn<TResult, T1, T2, T3>(this IMethodInvocation invocation, TResult result, T1 arg1, T2 arg2, T3 arg3)
+            => invocation.CreateValueReturn(result, ArgumentCollection.Create(invocation.MethodBase.GetParameters(), arg1, arg2, arg3));
+
+        /// <summary>
+        /// Creates the method invocation return that ends the current invocation for a non-void method.
+        /// </summary>
+        public static IMethodReturn CreateValueReturn<TResult, T1, T2, T3, T4>(this IMethodInvocation invocation, TResult result, T1 arg1, T2 arg2, T3 arg3, T4 arg4)
+            => invocation.CreateValueReturn(result, ArgumentCollection.Create(invocation.MethodBase.GetParameters(), arg1, arg2, arg3, arg4));
+
+        /// <summary>
+        /// Creates the method invocation return that ends the current invocation for a non-void method.
+        /// </summary>
+        public static IMethodReturn CreateValueReturn<TResult, T1, T2, T3, T4, T5>(this IMethodInvocation invocation, TResult result, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5)
+            => invocation.CreateValueReturn(result, ArgumentCollection.Create(invocation.MethodBase.GetParameters(), arg1, arg2, arg3, arg4, arg5));
+
+        /// <summary>
+        /// Creates the method invocation return that ends the current invocation for a non-void method.
+        /// </summary>
+        public static IMethodReturn CreateValueReturn<TResult, T1, T2, T3, T4, T5, T6>(this IMethodInvocation invocation, TResult result, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6)
+            => invocation.CreateValueReturn(result, ArgumentCollection.Create(invocation.MethodBase.GetParameters(), arg1, arg2, arg3, arg4, arg5, arg6));
+
+        /// <summary>
+        /// Creates the method invocation return that ends the current invocation for a non-void method.
+        /// </summary>
+        public static IMethodReturn CreateValueReturn<TResult, T1, T2, T3, T4, T5, T6, T7>(this IMethodInvocation invocation, TResult result, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7)
+            => invocation.CreateValueReturn(result, ArgumentCollection.Create(invocation.MethodBase.GetParameters(), arg1, arg2, arg3, arg4, arg5, arg6, arg7));
+
+        /// <summary>
+        /// Creates the method invocation return that ends the current invocation for a non-void method.
+        /// </summary>
+        public static IMethodReturn CreateValueReturn<TResult, T1, T2, T3, T4, T5, T6, T7, T8>(this IMethodInvocation invocation, TResult result, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8)
+            => invocation.CreateValueReturn(result, ArgumentCollection.Create(invocation.MethodBase.GetParameters(), arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8));
+
+        /// <summary>
+        /// Creates the method invocation return that ends the current invocation for a non-void method.
+        /// </summary>
+        public static IMethodReturn CreateValueReturn<TResult, T1, T2, T3, T4, T5, T6, T7, T8, T9>(this IMethodInvocation invocation, TResult result, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9)
+            => invocation.CreateValueReturn(result, ArgumentCollection.Create(invocation.MethodBase.GetParameters(), arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9));
+
+        /// <summary>
+        /// Creates the method invocation return that ends the current invocation for a non-void method.
+        /// </summary>
+        public static IMethodReturn CreateValueReturn<TResult, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(this IMethodInvocation invocation, TResult result, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10)
+            => invocation.CreateValueReturn(result, ArgumentCollection.Create(invocation.MethodBase.GetParameters(), arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10));
+
+        /// <summary>
+        /// Creates the method invocation return that ends the current invocation for a non-void method.
+        /// </summary>
+        public static IMethodReturn CreateValueReturn<TResult, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(this IMethodInvocation invocation, TResult result, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11)
+            => invocation.CreateValueReturn(result, ArgumentCollection.Create(invocation.MethodBase.GetParameters(), arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11));
+
+        /// <summary>
+        /// Creates the method invocation return that ends the current invocation for a non-void method.
+        /// </summary>
+        public static IMethodReturn CreateValueReturn<TResult, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(this IMethodInvocation invocation, TResult result, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12)
+            => invocation.CreateValueReturn(result, ArgumentCollection.Create(invocation.MethodBase.GetParameters(), arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12));
+
+        /// <summary>
+        /// Creates the method invocation return that ends the current invocation for a non-void method.
+        /// </summary>
+        public static IMethodReturn CreateValueReturn<TResult, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(this IMethodInvocation invocation, TResult result, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13)
+            => invocation.CreateValueReturn(result, ArgumentCollection.Create(invocation.MethodBase.GetParameters(), arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13));
+
+        /// <summary>
+        /// Creates the method invocation return that ends the current invocation for a non-void method.
+        /// </summary>
+        public static IMethodReturn CreateValueReturn<TResult, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(this IMethodInvocation invocation, TResult result, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14)
+            => invocation.CreateValueReturn(result, ArgumentCollection.Create(invocation.MethodBase.GetParameters(), arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14));
+
+        /// <summary>
+        /// Creates the method invocation return that ends the current invocation for a non-void method.
+        /// </summary>
+        public static IMethodReturn CreateValueReturn<TResult, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(this IMethodInvocation invocation, TResult result, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15)
+            => invocation.CreateValueReturn(result, ArgumentCollection.Create(invocation.MethodBase.GetParameters(), arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15));
+
+        /// <summary>
+        /// Creates the method invocation return that ends the current invocation for a non-void method.
+        /// </summary>
+        public static IMethodReturn CreateValueReturn<TResult, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(this IMethodInvocation invocation, TResult result, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15, T16 arg16)
+            => invocation.CreateValueReturn(result, ArgumentCollection.Create(invocation.MethodBase.GetParameters(), arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16));
     }
 }

--- a/src/Avatar/MethodReturn.cs
+++ b/src/Avatar/MethodReturn.cs
@@ -91,11 +91,9 @@ namespace Avatars
 
         IArgumentCollection GetOutputs(IArgumentCollection arguments)
         {
-            var outputs = new ArgumentCollection(invocation.MethodBase.GetParameters()
-                .Where(x => x.ParameterType.IsByRef || x.IsOut).ToArray());
-
-            foreach (var info in outputs)
-                outputs.Add(info.Name, arguments.GetValue(info.Name));
+            var outputs = new ArgumentCollection(
+                arguments.Where(x => x.Parameter.ParameterType.IsByRef || x.Parameter.IsOut)
+                .ToArray());
 
             return outputs;
         }

--- a/src/Avatar/Ref.cs
+++ b/src/Avatar/Ref.cs
@@ -4,7 +4,7 @@ using System.Reflection;
 namespace Avatars
 {
     /// <summary>
-    /// Contains a reflection-based factory for <see cref="Ref{T}"/>.
+    /// Contains a factory methods for <see cref="Ref{T}"/>.
     /// </summary>
     public class Ref
     {

--- a/src/Avatar/Resources.resx
+++ b/src/Avatar/Resources.resx
@@ -127,13 +127,13 @@
     <value>Default factory does not implement avatar creation. Please ensure AvatarFactory.Default is assigned to a valid factory before usage.</value>
   </data>
   <data name="ValueIsNull" xml:space="preserve">
-    <value>Expected argument {arg} to be non-null.</value>
+    <value>Expected argument '{arg}' to be non-null.</value>
   </data>
   <data name="ValueNotCompatible" xml:space="preserve">
-    <value>Requested {arg} has a value of type {actualType} which cannot be converted to the requested type {requestedType}.</value>
+    <value>Requested '{arg}' has a value of type '{actualType}' which cannot be converted to the expected type '{requestedType}'.</value>
   </data>
   <data name="ValueTypeIsNull" xml:space="preserve">
-    <value>Argument {arg} is null and cannot be converted to requested type {type} because it is not a nullable value type.</value>
+    <value>Argument '{arg}' is null and cannot be converted to expected type '{type}' because it is not a nullable value type.</value>
   </data>
   <data name="StaticAvatarTypeNotFoundInAssembly" xml:space="preserve">
     <value>Expected avatar type named '{type}' in assembly '{assembly}' was not found. The static source generator may have failed to generate the required types during build, or the avatar types may be located in a different assembly.</value>
@@ -158,5 +158,8 @@
   </data>
   <data name="PipelineNotImplemented" xml:space="preserve">
     <value>No implementation found for {method}.</value>
+  </data>
+  <data name="TypeNotCompatible" xml:space="preserve">
+    <value>Argument type '{argType}' is not compatible with its parameter '{paramType} {paramName}'.</value>
   </data>
 </root>

--- a/src/ManualAvatars/CalculatorClassAvatar.cs
+++ b/src/ManualAvatars/CalculatorClassAvatar.cs
@@ -14,36 +14,36 @@ namespace Sample
 
         public override event EventHandler TurnedOn
         {
-            add => pipeline.Execute(new MethodInvocation(this, MethodBase.GetCurrentMethod(), (m, n) => { base.TurnedOn += value; return m.CreateValueReturn(null, m.Arguments); }, value));
-            remove => pipeline.Execute(new MethodInvocation(this, MethodBase.GetCurrentMethod(), (m, n) => { base.TurnedOn -= value; return m.CreateValueReturn(null, m.Arguments); }, value));
+            add => pipeline.Execute(MethodInvocation.Create(this, MethodBase.GetCurrentMethod(), (m, n) => { base.TurnedOn += value; return m.CreateValueReturn(null, m.Arguments); }, value));
+            remove => pipeline.Execute(MethodInvocation.Create(this, MethodBase.GetCurrentMethod(), (m, n) => { base.TurnedOn -= value; return m.CreateValueReturn(null, m.Arguments); }, value));
         }
 
         public override CalculatorMode Mode
         {
-            get => pipeline.Execute<CalculatorMode>(new MethodInvocation(this, MethodBase.GetCurrentMethod(), (m, n) => m.CreateValueReturn(base.Mode)));
-            set => pipeline.Invoke(new MethodInvocation(this, MethodBase.GetCurrentMethod(), (m, n) => { base.Mode = value; return m.CreateValueReturn(null, m.Arguments); }, value));
+            get => pipeline.Execute<CalculatorMode>(MethodInvocation.Create(this, MethodBase.GetCurrentMethod(), (m, n) => m.CreateValueReturn(base.Mode)));
+            set => pipeline.Invoke(MethodInvocation.Create(this, MethodBase.GetCurrentMethod(), (m, n) => { base.Mode = value; return m.CreateValueReturn(null, m.Arguments); }, value));
         }
 
         public override int? this[string name]
         {
-            get => pipeline.Execute<int?>(new MethodInvocation(this, MethodBase.GetCurrentMethod(), (m, n) => m.CreateValueReturn(base[name]), name));
-            set => pipeline.Execute(new MethodInvocation(this, MethodBase.GetCurrentMethod(), (m, n) => { base[name] = value; return m.CreateValueReturn(null, m.Arguments); }, name, value));
+            get => pipeline.Execute<int?>(MethodInvocation.Create(this, MethodBase.GetCurrentMethod(), (m, n) => m.CreateValueReturn(base[name]), name));
+            set => pipeline.Execute(MethodInvocation.Create(this, MethodBase.GetCurrentMethod(), (m, n) => { base[name] = value; return m.CreateValueReturn(null, m.Arguments); }, name, value));
         }
 
-        public override bool IsOn => pipeline.Execute<bool>(new MethodInvocation(this, MethodBase.GetCurrentMethod(), (m, n) => m.CreateValueReturn(base.IsOn)));
+        public override bool IsOn => pipeline.Execute<bool>(MethodInvocation.Create(this, MethodBase.GetCurrentMethod(), (m, n) => m.CreateValueReturn(base.IsOn)));
 
         public override int Add(int x, int y) =>
-            pipeline.Execute<int>(new MethodInvocation(this, MethodBase.GetCurrentMethod(), (m, n) => m.CreateValueReturn(base.Add(x, y), m.Arguments), x, y));
+            pipeline.Execute<int>(MethodInvocation.Create(this, MethodBase.GetCurrentMethod(), (m, n) => m.CreateValueReturn(base.Add(x, y), m.Arguments), x, y));
 
         public override int Add(int x, int y, int z) =>
-            pipeline.Execute<int>(new MethodInvocation(this, MethodBase.GetCurrentMethod(), (m, n) => m.CreateValueReturn(base.Add(x, y, z), m.Arguments), x, y, z));
+            pipeline.Execute<int>(MethodInvocation.Create(this, MethodBase.GetCurrentMethod(), (m, n) => m.CreateValueReturn(base.Add(x, y, z), m.Arguments), x, y, z));
 
         public override bool TryAdd(ref int x, ref int y, out int z)
         {
             var method = MethodBase.GetCurrentMethod();
             z = default;
 
-            var result = pipeline.Invoke(new MethodInvocation(this, method,
+            var result = pipeline.Invoke(MethodInvocation.Create(this, method,
                 (m, n) =>
                 {
                     var local_x = m.Arguments.Get<int>("x");
@@ -56,7 +56,13 @@ namespace Sample
                             { "y", local_y },
                             { "z", local_z },
                         });
-                }, x, y, z), true);
+                },
+                new ArgumentCollection(method.GetParameters())
+                {
+                    { "x", x },
+                    { "y", y },
+                    { "z", z },
+                }), true);
 
             x = result.Outputs.GetNullable<int>("x");
             y = result.Outputs.GetNullable<int>("y");
@@ -66,20 +72,20 @@ namespace Sample
         }
 
         public override void TurnOn() =>
-            pipeline.Execute(new MethodInvocation(this, MethodBase.GetCurrentMethod(), (m, n) => { base.TurnOn(); return m.CreateValueReturn(null); }));
+            pipeline.Execute(MethodInvocation.Create(this, MethodBase.GetCurrentMethod(), (m, n) => { base.TurnOn(); return m.CreateReturn(); }));
 
         public override void Store(string name, int value) =>
-            pipeline.Execute(new MethodInvocation(this, MethodBase.GetCurrentMethod(), (m, n) => { base.Store(name, value); return m.CreateValueReturn(null, m.Arguments); }, name, value));
+            pipeline.Execute(MethodInvocation.Create(this, MethodBase.GetCurrentMethod(), (m, n) => { base.Store(name, value); return m.CreateReturn(m.Arguments); }, name, value));
 
         public override int? Recall(string name) =>
-            pipeline.Execute<int?>(new MethodInvocation(this, MethodBase.GetCurrentMethod(), (m, n) => m.CreateValueReturn(base.Recall(name), m.Arguments), name));
+            pipeline.Execute<int?>(MethodInvocation.Create(this, MethodBase.GetCurrentMethod(), (m, n) => m.CreateValueReturn(base.Recall(name), m.Arguments), name));
 
         public override void Clear(string name) =>
-            pipeline.Execute(new MethodInvocation(this, MethodBase.GetCurrentMethod(), (m, n) => { base.Clear(name); return m.CreateValueReturn(null, m.Arguments); }, name));
+            pipeline.Execute(MethodInvocation.Create(this, MethodBase.GetCurrentMethod(), (m, n) => { base.Clear(name); return m.CreateReturn(m.Arguments); }, name));
 
         public override ICalculatorMemory Memory
         {
-            get => pipeline.Execute<ICalculatorMemory>(new MethodInvocation(this, MethodBase.GetCurrentMethod(), (m, n) => m.CreateValueReturn(base.Memory)));
+            get => pipeline.Execute<ICalculatorMemory>(MethodInvocation.Create(this, MethodBase.GetCurrentMethod(), (m, n) => m.CreateValueReturn(base.Memory)));
         }
     }
 }

--- a/src/ManualAvatars/CalculatorInterfaceAvatar.cs
+++ b/src/ManualAvatars/CalculatorInterfaceAvatar.cs
@@ -8,41 +8,41 @@ namespace Sample
 {
     public class CalculatorInterfaceAvatar : ICalculator, IDisposable, IAvatar
     {
-        BehaviorPipeline pipeline = new BehaviorPipeline();
+        readonly BehaviorPipeline pipeline = new();
 
         IList<IAvatarBehavior> IAvatar.Behaviors => pipeline.Behaviors;
 
         public event EventHandler TurnedOn
         {
-            add => pipeline.Execute(new MethodInvocation(this, MethodBase.GetCurrentMethod(), value));
-            remove => pipeline.Execute(new MethodInvocation(this, MethodBase.GetCurrentMethod(), value));
+            add => pipeline.Execute(MethodInvocation.Create(this, MethodBase.GetCurrentMethod(), value));
+            remove => pipeline.Execute(MethodInvocation.Create(this, MethodBase.GetCurrentMethod(), value));
         }
 
         public bool IsOn
         {
-            get => pipeline.Execute<bool>(new MethodInvocation(this, MethodBase.GetCurrentMethod()));
+            get => pipeline.Execute<bool>(MethodInvocation.Create(this, MethodBase.GetCurrentMethod()));
         }
 
         public CalculatorMode Mode
         {
-            get => pipeline.Execute<CalculatorMode>(new MethodInvocation(this, MethodBase.GetCurrentMethod()));
-            set => pipeline.Execute(new MethodInvocation(this, MethodBase.GetCurrentMethod(), value));
+            get => pipeline.Execute<CalculatorMode>(MethodInvocation.Create(this, MethodBase.GetCurrentMethod()));
+            set => pipeline.Execute(MethodInvocation.Create(this, MethodBase.GetCurrentMethod(), value));
         }
 
         public int? this[string name]
         {
-            get => pipeline.Execute<int?>(new MethodInvocation(this, MethodBase.GetCurrentMethod(), name));
-            set => pipeline.Execute(new MethodInvocation(this, MethodBase.GetCurrentMethod(), name, value));
+            get => pipeline.Execute<int?>(MethodInvocation.Create(this, MethodBase.GetCurrentMethod(), name));
+            set => pipeline.Execute(MethodInvocation.Create(this, MethodBase.GetCurrentMethod(), name, value));
         }
 
-        public int Add(int x, int y) => pipeline.Execute<int>(new MethodInvocation(this, MethodBase.GetCurrentMethod(), x, y));
+        public int Add(int x, int y) => pipeline.Execute<int>(MethodInvocation.Create(this, MethodBase.GetCurrentMethod(), x, y));
 
-        public int Add(int x, int y, int z) => pipeline.Execute<int>(new MethodInvocation(this, MethodBase.GetCurrentMethod(), x, y, z));
+        public int Add(int x, int y, int z) => pipeline.Execute<int>(MethodInvocation.Create(this, MethodBase.GetCurrentMethod(), x, y, z));
 
         public bool TryAdd(ref int x, ref int y, out int z)
         {
             z = default;
-            var returns = pipeline.Execute(new MethodInvocation(this, MethodBase.GetCurrentMethod(), x, y, z));
+            var returns = pipeline.Execute(MethodInvocation.Create(this, MethodBase.GetCurrentMethod(), x, y, z));
 
             x = returns.Outputs.GetNullable<int>("x");
             y = returns.Outputs.GetNullable<int>("y");
@@ -51,19 +51,19 @@ namespace Sample
             return (bool)returns.ReturnValue!;
         }
 
-        public void TurnOn() => pipeline.Execute(new MethodInvocation(this, MethodBase.GetCurrentMethod()));
+        public void TurnOn() => pipeline.Execute(MethodInvocation.Create(this, MethodBase.GetCurrentMethod()));
 
-        public void Store(string name, int value) => pipeline.Execute(new MethodInvocation(this, MethodBase.GetCurrentMethod(), name, value));
+        public void Store(string name, int value) => pipeline.Execute(MethodInvocation.Create(this, MethodBase.GetCurrentMethod(), name, value));
 
-        public int? Recall(string name) => pipeline.Execute<int?>(new MethodInvocation(this, MethodBase.GetCurrentMethod(), name));
+        public int? Recall(string name) => pipeline.Execute<int?>(MethodInvocation.Create(this, MethodBase.GetCurrentMethod(), name));
 
-        public void Clear(string name) => pipeline.Execute(new MethodInvocation(this, MethodBase.GetCurrentMethod(), name));
+        public void Clear(string name) => pipeline.Execute(MethodInvocation.Create(this, MethodBase.GetCurrentMethod(), name));
 
-        public void Dispose() => pipeline.Execute(new MethodInvocation(this, MethodBase.GetCurrentMethod()));
+        public void Dispose() => pipeline.Execute(MethodInvocation.Create(this, MethodBase.GetCurrentMethod()));
 
         public ICalculatorMemory Memory
         {
-            get => pipeline.Execute<ICalculatorMemory>(new MethodInvocation(this, MethodBase.GetCurrentMethod()))!;
+            get => pipeline.Execute<ICalculatorMemory>(MethodInvocation.Create(this, MethodBase.GetCurrentMethod()))!;
         }
     }
 }

--- a/src/ManualAvatars/CalculatorInterfaceAvatar.cs
+++ b/src/ManualAvatars/CalculatorInterfaceAvatar.cs
@@ -14,8 +14,8 @@ namespace Sample
 
         public event EventHandler TurnedOn
         {
-            add => pipeline.Execute(new MethodInvocation(this, MethodBase.GetCurrentMethod()));
-            remove => pipeline.Execute(new MethodInvocation(this, MethodBase.GetCurrentMethod()));
+            add => pipeline.Execute(new MethodInvocation(this, MethodBase.GetCurrentMethod(), value));
+            remove => pipeline.Execute(new MethodInvocation(this, MethodBase.GetCurrentMethod(), value));
         }
 
         public bool IsOn


### PR DESCRIPTION
Previously we had code in quite a few places that would get the `ParameterInfo` from the argument collection, and then do something with the (untyped) object value subsequently. Since the collection was not typed, we were forcing boxing of every argument value, which in turn would prevent types that cannot be boxed in the future (such as Span<T>).

In addition, the validation of the argument value assignment according to its parameter info was quite loose and had to be accounted in more than one place too.

This commit adds a strong-typed `Argument<T>` record class (and its base un-typed class) which is now used consistently. It's also used to validate the type conversions so this is consistent regardless of which other APIs that end up creating argument collections are used.

In order to make it easy to create strong-typed argument collections, a bunch of generic factory method overloads were added to make this seamless:

* `ArgumentCollection.Create<...>(parameters, args)`
* `MethodInvocation.Create<...>`
* `IMethodInvocation.CreateResult<...>` and `CreateValueResult<...>` extension methods.

The first one is the actual one creating the typed arguments. The others are mostly pass-through to it, and are added as convenience to avoid having to invoke `Argument.Create<...>` explicitly, especially since the `ParameterInfo[]` to use in the collection is always the one in the method invocation itself.

Fixes #74.