### PR TITLE
Use local function in pipleline invocation to avoid delegate allocation

### DIFF
--- a/src/Avatar/BehaviorPipeline.cs
+++ b/src/Avatar/BehaviorPipeline.cs
@@ -101,7 +101,7 @@ namespace Avatars
             if (index == -1)
                 return CallBaseOrThrow(invocation);
 
-            Func<ExecuteHandler> getNext = () =>
+            ExecuteHandler GetNext()
             {
                 for (index++; index < behaviors.Length; index++)
                     if (!invocation.SkipBehaviors.Contains(behaviors[index].GetType()) && behaviors[index].AppliesTo(invocation))
@@ -110,9 +110,9 @@ namespace Avatars
                 return (index < behaviors.Length) ?
                     behaviors[index].Execute :
                     (m, n) => CallBaseOrThrow(m);
-            };
+            }
 
-            var result = behaviors[index].Execute(invocation, (m, n) => getNext().Invoke(m, n));
+            var result = behaviors[index].Execute(invocation, (m, n) => GetNext().Invoke(m, n));
 
             if (throwOnException && result.Exception != null)
                 throw result.Exception;


### PR DESCRIPTION
I was browsing the sources of this project, being curious how it was implemented (very cool stuff), and saw a tiny improvement that I thought I'd submit as a PR.

`BehaviourPipeline.Invoke` uses a delegate instance for fetching the next handler in the chain. With this PR, I am proposing to replace it with a local function to avoid the extra and unnecessary allocation of a delegate.
