### PR TITLE
Rename callBase to implementation

### DIFF
--- a/src/Avatar/BehaviorPipeline.cs
+++ b/src/Avatar/BehaviorPipeline.cs
@@ -76,12 +76,12 @@ namespace Avatars
         /// <returns>Return value from the pipeline.</returns>
         public IMethodReturn Invoke(IMethodInvocation invocation, bool throwOnException = false)
         {
-            IMethodReturn CallBaseOrThrow(IMethodInvocation invocation) => invocation.SupportsCallBase ?
-                invocation.CreateCallBaseReturn() :
-                throw new NotImplementedException(ThisAssembly.Strings.PipelineNotImplemented(invocation));
+            IMethodReturn InvokeTargetOrThrow(IMethodInvocation invocation) => invocation.HasImplementation ?
+                invocation.CreateInvokeReturn() :
+                throw new NotImplementedException(ThisAssembly.Strings.NotImplemented(invocation));
 
             if (Behaviors.Count == 0)
-                return CallBaseOrThrow(invocation);
+                return InvokeTargetOrThrow(invocation);
 
             // We convert to array so that the collection of behaviors can potentially 
             // be modified by behaviors themselves for a subsequent pipeline execution. 
@@ -99,7 +99,7 @@ namespace Avatars
             }
 
             if (index == -1)
-                return CallBaseOrThrow(invocation);
+                return InvokeTargetOrThrow(invocation);
 
             ExecuteHandler GetNext()
             {
@@ -109,7 +109,7 @@ namespace Avatars
 
                 return (index < behaviors.Length) ?
                     behaviors[index].Execute :
-                    (m, n) => CallBaseOrThrow(m);
+                    (m, n) => InvokeTargetOrThrow(m);
             }
 
             var result = behaviors[index].Execute(invocation, (m, n) => GetNext().Invoke(m, n));

--- a/src/Avatar/IMethodInvocation.cs
+++ b/src/Avatar/IMethodInvocation.cs
@@ -25,8 +25,7 @@ namespace Avatars
         MethodBase MethodBase { get; }
 
         /// <summary>
-        /// The ultimate target of the method invocation, typically 
-        /// an avatar object.
+        /// The avatar object that was the target of the method invocation.
         /// </summary>
         object Target { get; }
 
@@ -36,23 +35,29 @@ namespace Avatars
         HashSet<Type> SkipBehaviors { get; }
 
         /// <summary>
-        /// Whether the invocation has a base call target that can be invoked via 
-        /// <see cref="CreateCallBaseReturn"/>.
+        /// Whether the method has a built-in implementation that can be invoked via 
+        /// <see cref="CreateInvokeReturn"/>.
         /// </summary>
-        bool SupportsCallBase { get; }
+        /// <remarks>
+        /// For a class-based avatar, this would be <see langword="true"/> for virtual 
+        /// methods, for an interface-based avatar, it would be <see langword="true"/> 
+        /// if a target implementation instance was provided (i.e. as a decorator pattern).
+        /// </remarks>
+        bool HasImplementation { get; }
 
         /// <summary>
-        /// Creates the method invocation return that ends the current invocation by invoking the 
-        /// base method implementation, optionally overriding the arguments passed to that invocation.
+        /// Invokes the underlying implementation of the method, if <see cref="HasImplementation"/> 
+        /// is <see langword="true"/>, optionally overriding the arguments passed to that invocation.
         /// </summary>
         /// <param name="arguments">Ordered list of all arguments to the method invocation, including ref/out arguments.
         /// If not provided, the arguments from the invocation will be used.</param>
         /// <returns>The <see cref="IMethodReturn"/> for the current invocation.</returns>
         /// <exception cref="NotImplementedException">The current method invocation does not have a 
-        /// base implementation. In other words, it's either abstract or a member of an interface.</exception>
-        /// <exception cref="NotSupportedException">The call base implementation attempted to get the 
+        /// base implementation. In other words, it's either abstract or a member of an interface (with 
+        /// no target implementation).</exception>
+        /// <exception cref="NotSupportedException">The target invocation attempted to get the 
         /// next behavior, which is not supported.</exception>
-        IMethodReturn CreateCallBaseReturn(IArgumentCollection? arguments = null);
+        IMethodReturn CreateInvokeReturn(IArgumentCollection? arguments = null);
 
         /// <summary>
         /// Creates the method invocation return that ends the current invocation by providing 

--- a/src/Avatar/MethodInvocation.Create.cs
+++ b/src/Avatar/MethodInvocation.Create.cs
@@ -121,108 +121,108 @@ namespace Avatars
         /// </summary>
         /// <param name="target">The target of the invocation.</param>
         /// <param name="method">The method being invoked.</param>
-        /// <param name="callBase">Delegate to invoke the base method implementation for virtual methods.</param>
-        public static MethodInvocation Create(object target, MethodBase method, ExecuteHandler callBase) => new MethodInvocation(target, method, callBase, new ArgumentCollection());
+        /// <param name="implementation">Delegate to invoke the base method implementation for virtual methods.</param>
+        public static MethodInvocation Create(object target, MethodBase method, ExecuteHandler implementation) => new MethodInvocation(target, method, implementation, new ArgumentCollection());
 
         /// <summary>
         /// Creates a method invocation with the given typed argument value.
         /// </summary>
         /// <param name="target">The target of the invocation.</param>
         /// <param name="method">The method being invoked.</param>
-        /// <param name="callBase">Delegate to invoke the base method implementation for virtual methods.</param>
+        /// <param name="implementation">Delegate to invoke the base method implementation for virtual methods.</param>
         /// <param name="arg">The argument value.</param>
-        public static MethodInvocation Create<T>(object target, MethodBase method, ExecuteHandler callBase, T arg)
-            => new MethodInvocation(target, method, callBase, ArgumentCollection.Create(method.GetParameters(), arg));
+        public static MethodInvocation Create<T>(object target, MethodBase method, ExecuteHandler implementation, T arg)
+            => new MethodInvocation(target, method, implementation, ArgumentCollection.Create(method.GetParameters(), arg));
 
         /// <summary>
         /// Creates a method invocation with the given typed argument values.
         /// </summary>
-        public static MethodInvocation Create<T1, T2>(object target, MethodBase method, ExecuteHandler callBase, T1 arg1, T2 arg2)
-            => new MethodInvocation(target, method, callBase, ArgumentCollection.Create(method.GetParameters(), arg1, arg2));
+        public static MethodInvocation Create<T1, T2>(object target, MethodBase method, ExecuteHandler implementation, T1 arg1, T2 arg2)
+            => new MethodInvocation(target, method, implementation, ArgumentCollection.Create(method.GetParameters(), arg1, arg2));
 
         /// <summary>
         /// Creates a method invocation with the given typed argument values.
         /// </summary>
-        public static MethodInvocation Create<T1, T2, T3>(object target, MethodBase method, ExecuteHandler callBase, T1 arg1, T2 arg2, T3 arg3)
-            => new MethodInvocation(target, method, callBase, ArgumentCollection.Create(method.GetParameters(), arg1, arg2, arg3));
+        public static MethodInvocation Create<T1, T2, T3>(object target, MethodBase method, ExecuteHandler implementation, T1 arg1, T2 arg2, T3 arg3)
+            => new MethodInvocation(target, method, implementation, ArgumentCollection.Create(method.GetParameters(), arg1, arg2, arg3));
 
         /// <summary>
         /// Creates a method invocation with the given typed argument values.
         /// </summary>
-        public static MethodInvocation Create<T1, T2, T3, T4>(object target, MethodBase method, ExecuteHandler callBase, T1 arg1, T2 arg2, T3 arg3, T4 arg4)
-            => new MethodInvocation(target, method, callBase, ArgumentCollection.Create(method.GetParameters(), arg1, arg2, arg3, arg4));
+        public static MethodInvocation Create<T1, T2, T3, T4>(object target, MethodBase method, ExecuteHandler implementation, T1 arg1, T2 arg2, T3 arg3, T4 arg4)
+            => new MethodInvocation(target, method, implementation, ArgumentCollection.Create(method.GetParameters(), arg1, arg2, arg3, arg4));
 
         /// <summary>
         /// Creates a method invocation with the given typed argument values.
         /// </summary>
-        public static MethodInvocation Create<T1, T2, T3, T4, T5>(object target, MethodBase method, ExecuteHandler callBase, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5)
-            => new MethodInvocation(target, method, callBase, ArgumentCollection.Create(method.GetParameters(), arg1, arg2, arg3, arg4, arg5));
+        public static MethodInvocation Create<T1, T2, T3, T4, T5>(object target, MethodBase method, ExecuteHandler implementation, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5)
+            => new MethodInvocation(target, method, implementation, ArgumentCollection.Create(method.GetParameters(), arg1, arg2, arg3, arg4, arg5));
 
         /// <summary>
         /// Creates a method invocation with the given typed argument values.
         /// </summary>
-        public static MethodInvocation Create<T1, T2, T3, T4, T5, T6>(object target, MethodBase method, ExecuteHandler callBase, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6)
-            => new MethodInvocation(target, method, callBase, ArgumentCollection.Create(method.GetParameters(), arg1, arg2, arg3, arg4, arg5, arg6));
+        public static MethodInvocation Create<T1, T2, T3, T4, T5, T6>(object target, MethodBase method, ExecuteHandler implementation, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6)
+            => new MethodInvocation(target, method, implementation, ArgumentCollection.Create(method.GetParameters(), arg1, arg2, arg3, arg4, arg5, arg6));
 
         /// <summary>
         /// Creates a method invocation with the given typed argument values.
         /// </summary>
-        public static MethodInvocation Create<T1, T2, T3, T4, T5, T6, T7>(object target, MethodBase method, ExecuteHandler callBase, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7)
-            => new MethodInvocation(target, method, callBase, ArgumentCollection.Create(method.GetParameters(), arg1, arg2, arg3, arg4, arg5, arg6, arg7));
+        public static MethodInvocation Create<T1, T2, T3, T4, T5, T6, T7>(object target, MethodBase method, ExecuteHandler implementation, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7)
+            => new MethodInvocation(target, method, implementation, ArgumentCollection.Create(method.GetParameters(), arg1, arg2, arg3, arg4, arg5, arg6, arg7));
 
         /// <summary>
         /// Creates a method invocation with the given typed argument values.
         /// </summary>
-        public static MethodInvocation Create<T1, T2, T3, T4, T5, T6, T7, T8>(object target, MethodBase method, ExecuteHandler callBase, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8)
-            => new MethodInvocation(target, method, callBase, ArgumentCollection.Create(method.GetParameters(), arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8));
+        public static MethodInvocation Create<T1, T2, T3, T4, T5, T6, T7, T8>(object target, MethodBase method, ExecuteHandler implementation, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8)
+            => new MethodInvocation(target, method, implementation, ArgumentCollection.Create(method.GetParameters(), arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8));
 
         /// <summary>
         /// Creates a method invocation with the given typed argument values.
         /// </summary>
-        public static MethodInvocation Create<T1, T2, T3, T4, T5, T6, T7, T8, T9>(object target, MethodBase method, ExecuteHandler callBase, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9)
-            => new MethodInvocation(target, method, callBase, ArgumentCollection.Create(method.GetParameters(), arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9));
+        public static MethodInvocation Create<T1, T2, T3, T4, T5, T6, T7, T8, T9>(object target, MethodBase method, ExecuteHandler implementation, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9)
+            => new MethodInvocation(target, method, implementation, ArgumentCollection.Create(method.GetParameters(), arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9));
 
         /// <summary>
         /// Creates a method invocation with the given typed argument values.
         /// </summary>
-        public static MethodInvocation Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(object target, MethodBase method, ExecuteHandler callBase, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10)
-            => new MethodInvocation(target, method, callBase, ArgumentCollection.Create(method.GetParameters(), arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10));
+        public static MethodInvocation Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(object target, MethodBase method, ExecuteHandler implementation, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10)
+            => new MethodInvocation(target, method, implementation, ArgumentCollection.Create(method.GetParameters(), arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10));
 
         /// <summary>
         /// Creates a method invocation with the given typed argument values.
         /// </summary>
-        public static MethodInvocation Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(object target, MethodBase method, ExecuteHandler callBase, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11)
-            => new MethodInvocation(target, method, callBase, ArgumentCollection.Create(method.GetParameters(), arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11));
+        public static MethodInvocation Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(object target, MethodBase method, ExecuteHandler implementation, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11)
+            => new MethodInvocation(target, method, implementation, ArgumentCollection.Create(method.GetParameters(), arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11));
 
         /// <summary>
         /// Creates a method invocation with the given typed argument values.
         /// </summary>
-        public static MethodInvocation Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(object target, MethodBase method, ExecuteHandler callBase, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12)
-            => new MethodInvocation(target, method, callBase, ArgumentCollection.Create(method.GetParameters(), arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12));
+        public static MethodInvocation Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(object target, MethodBase method, ExecuteHandler implementation, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12)
+            => new MethodInvocation(target, method, implementation, ArgumentCollection.Create(method.GetParameters(), arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12));
 
         /// <summary>
         /// Creates a method invocation with the given typed argument values.
         /// </summary>
-        public static MethodInvocation Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(object target, MethodBase method, ExecuteHandler callBase, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13)
-            => new MethodInvocation(target, method, callBase, ArgumentCollection.Create(method.GetParameters(), arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13));
+        public static MethodInvocation Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(object target, MethodBase method, ExecuteHandler implementation, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13)
+            => new MethodInvocation(target, method, implementation, ArgumentCollection.Create(method.GetParameters(), arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13));
 
         /// <summary>
         /// Creates a method invocation with the given typed argument values.
         /// </summary>
-        public static MethodInvocation Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(object target, MethodBase method, ExecuteHandler callBase, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14)
-            => new MethodInvocation(target, method, callBase, ArgumentCollection.Create(method.GetParameters(), arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14));
+        public static MethodInvocation Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(object target, MethodBase method, ExecuteHandler implementation, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14)
+            => new MethodInvocation(target, method, implementation, ArgumentCollection.Create(method.GetParameters(), arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14));
 
         /// <summary>
         /// Creates a method invocation with the given typed argument values.
         /// </summary>
-        public static MethodInvocation Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(object target, MethodBase method, ExecuteHandler callBase, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15)
-            => new MethodInvocation(target, method, callBase, ArgumentCollection.Create(method.GetParameters(), arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15));
+        public static MethodInvocation Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(object target, MethodBase method, ExecuteHandler implementation, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15)
+            => new MethodInvocation(target, method, implementation, ArgumentCollection.Create(method.GetParameters(), arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15));
 
         /// <summary>
         /// Creates a method invocation with the given typed argument values.
         /// </summary>
-        public static MethodInvocation Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(object target, MethodBase method, ExecuteHandler callBase, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15, T16 arg16)
-            => new MethodInvocation(target, method, callBase, ArgumentCollection.Create(method.GetParameters(), arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16));
+        public static MethodInvocation Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(object target, MethodBase method, ExecuteHandler implementation, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15, T16 arg16)
+            => new MethodInvocation(target, method, implementation, ArgumentCollection.Create(method.GetParameters(), arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16));
 
         #endregion
     }

--- a/src/Avatar/PublicAPI.Shipped.txt
+++ b/src/Avatar/PublicAPI.Shipped.txt
@@ -85,12 +85,12 @@ Avatars.IBehaviorPipelineFactory.CreatePipeline<TAvatar>() -> Avatars.BehaviorPi
 Avatars.IMethodInvocation
 Avatars.IMethodInvocation.Arguments.get -> Avatars.IArgumentCollection!
 Avatars.IMethodInvocation.Context.get -> System.Collections.Generic.IDictionary<string!, object!>!
-Avatars.IMethodInvocation.CreateCallBaseReturn(Avatars.IArgumentCollection? arguments = null) -> Avatars.IMethodReturn!
 Avatars.IMethodInvocation.CreateExceptionReturn(System.Exception! exception) -> Avatars.IMethodReturn!
+Avatars.IMethodInvocation.CreateInvokeReturn(Avatars.IArgumentCollection? arguments = null) -> Avatars.IMethodReturn!
 Avatars.IMethodInvocation.CreateValueReturn(object? returnValue, Avatars.IArgumentCollection! arguments) -> Avatars.IMethodReturn!
 Avatars.IMethodInvocation.MethodBase.get -> System.Reflection.MethodBase!
 Avatars.IMethodInvocation.SkipBehaviors.get -> System.Collections.Generic.HashSet<System.Type!>!
-Avatars.IMethodInvocation.SupportsCallBase.get -> bool
+Avatars.IMethodInvocation.HasImplementation.get -> bool
 Avatars.IMethodInvocation.Target.get -> object!
 Avatars.IMethodReturn
 Avatars.IMethodReturn.Context.get -> System.Collections.Generic.IDictionary<string!, object!>!
@@ -100,18 +100,18 @@ Avatars.IMethodReturn.ReturnValue.get -> object?
 Avatars.MethodInvocation
 Avatars.MethodInvocation.Arguments.get -> Avatars.IArgumentCollection!
 Avatars.MethodInvocation.Context.get -> System.Collections.Generic.IDictionary<string!, object!>!
-Avatars.MethodInvocation.CreateCallBaseReturn(Avatars.IArgumentCollection? arguments = null) -> Avatars.IMethodReturn!
 Avatars.MethodInvocation.CreateExceptionReturn(System.Exception! exception) -> Avatars.IMethodReturn!
+Avatars.MethodInvocation.CreateInvokeReturn(Avatars.IArgumentCollection? arguments = null) -> Avatars.IMethodReturn!
 Avatars.MethodInvocation.CreateValueReturn(object? returnValue, Avatars.IArgumentCollection! arguments) -> Avatars.IMethodReturn!
 Avatars.MethodInvocation.Equals(Avatars.IMethodInvocation? other) -> bool
 Avatars.MethodInvocation.Equals(Avatars.MethodInvocation! other) -> bool
 Avatars.MethodInvocation.MethodBase.get -> System.Reflection.MethodBase!
 Avatars.MethodInvocation.MethodInvocation(object! target, System.Reflection.MethodBase! method) -> void
-Avatars.MethodInvocation.MethodInvocation(object! target, System.Reflection.MethodBase! method, Avatars.ExecuteHandler! callBase) -> void
-Avatars.MethodInvocation.MethodInvocation(object! target, System.Reflection.MethodBase! method, Avatars.ExecuteHandler! callBase, Avatars.IArgumentCollection! arguments) -> void
+Avatars.MethodInvocation.MethodInvocation(object! target, System.Reflection.MethodBase! method, Avatars.ExecuteHandler! implementation) -> void
+Avatars.MethodInvocation.MethodInvocation(object! target, System.Reflection.MethodBase! method, Avatars.ExecuteHandler! implementation, Avatars.IArgumentCollection! arguments) -> void
 Avatars.MethodInvocation.MethodInvocation(object! target, System.Reflection.MethodBase! method, Avatars.IArgumentCollection! arguments) -> void
 Avatars.MethodInvocation.SkipBehaviors.get -> System.Collections.Generic.HashSet<System.Type!>!
-Avatars.MethodInvocation.SupportsCallBase.get -> bool
+Avatars.MethodInvocation.HasImplementation.get -> bool
 Avatars.MethodInvocation.Target.get -> object!
 Avatars.MethodInvocationExtensions
 Avatars.MethodReturn
@@ -210,38 +210,38 @@ static Avatars.BehaviorPipelineFactory.Default.set -> void
 static Avatars.BehaviorPipelineFactory.LocalDefault.get -> Avatars.IBehaviorPipelineFactory?
 static Avatars.BehaviorPipelineFactory.LocalDefault.set -> void
 static Avatars.MethodInvocation.Create(object! target, System.Reflection.MethodBase! method) -> Avatars.MethodInvocation!
-static Avatars.MethodInvocation.Create(object! target, System.Reflection.MethodBase! method, Avatars.ExecuteHandler! callBase) -> Avatars.MethodInvocation!
-static Avatars.MethodInvocation.Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(object! target, System.Reflection.MethodBase! method, Avatars.ExecuteHandler! callBase, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15, T16 arg16) -> Avatars.MethodInvocation!
+static Avatars.MethodInvocation.Create(object! target, System.Reflection.MethodBase! method, Avatars.ExecuteHandler! implementation) -> Avatars.MethodInvocation!
+static Avatars.MethodInvocation.Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(object! target, System.Reflection.MethodBase! method, Avatars.ExecuteHandler! implementation, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15, T16 arg16) -> Avatars.MethodInvocation!
 static Avatars.MethodInvocation.Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(object! target, System.Reflection.MethodBase! method, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15, T16 arg16) -> Avatars.MethodInvocation!
-static Avatars.MethodInvocation.Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(object! target, System.Reflection.MethodBase! method, Avatars.ExecuteHandler! callBase, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15) -> Avatars.MethodInvocation!
+static Avatars.MethodInvocation.Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(object! target, System.Reflection.MethodBase! method, Avatars.ExecuteHandler! implementation, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15) -> Avatars.MethodInvocation!
 static Avatars.MethodInvocation.Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(object! target, System.Reflection.MethodBase! method, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15) -> Avatars.MethodInvocation!
-static Avatars.MethodInvocation.Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(object! target, System.Reflection.MethodBase! method, Avatars.ExecuteHandler! callBase, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14) -> Avatars.MethodInvocation!
+static Avatars.MethodInvocation.Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(object! target, System.Reflection.MethodBase! method, Avatars.ExecuteHandler! implementation, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14) -> Avatars.MethodInvocation!
 static Avatars.MethodInvocation.Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(object! target, System.Reflection.MethodBase! method, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14) -> Avatars.MethodInvocation!
-static Avatars.MethodInvocation.Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(object! target, System.Reflection.MethodBase! method, Avatars.ExecuteHandler! callBase, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13) -> Avatars.MethodInvocation!
+static Avatars.MethodInvocation.Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(object! target, System.Reflection.MethodBase! method, Avatars.ExecuteHandler! implementation, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13) -> Avatars.MethodInvocation!
 static Avatars.MethodInvocation.Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(object! target, System.Reflection.MethodBase! method, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13) -> Avatars.MethodInvocation!
-static Avatars.MethodInvocation.Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(object! target, System.Reflection.MethodBase! method, Avatars.ExecuteHandler! callBase, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12) -> Avatars.MethodInvocation!
+static Avatars.MethodInvocation.Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(object! target, System.Reflection.MethodBase! method, Avatars.ExecuteHandler! implementation, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12) -> Avatars.MethodInvocation!
 static Avatars.MethodInvocation.Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(object! target, System.Reflection.MethodBase! method, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12) -> Avatars.MethodInvocation!
-static Avatars.MethodInvocation.Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(object! target, System.Reflection.MethodBase! method, Avatars.ExecuteHandler! callBase, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11) -> Avatars.MethodInvocation!
+static Avatars.MethodInvocation.Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(object! target, System.Reflection.MethodBase! method, Avatars.ExecuteHandler! implementation, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11) -> Avatars.MethodInvocation!
 static Avatars.MethodInvocation.Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(object! target, System.Reflection.MethodBase! method, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11) -> Avatars.MethodInvocation!
-static Avatars.MethodInvocation.Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(object! target, System.Reflection.MethodBase! method, Avatars.ExecuteHandler! callBase, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10) -> Avatars.MethodInvocation!
+static Avatars.MethodInvocation.Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(object! target, System.Reflection.MethodBase! method, Avatars.ExecuteHandler! implementation, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10) -> Avatars.MethodInvocation!
 static Avatars.MethodInvocation.Create<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(object! target, System.Reflection.MethodBase! method, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10) -> Avatars.MethodInvocation!
-static Avatars.MethodInvocation.Create<T1, T2, T3, T4, T5, T6, T7, T8, T9>(object! target, System.Reflection.MethodBase! method, Avatars.ExecuteHandler! callBase, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9) -> Avatars.MethodInvocation!
+static Avatars.MethodInvocation.Create<T1, T2, T3, T4, T5, T6, T7, T8, T9>(object! target, System.Reflection.MethodBase! method, Avatars.ExecuteHandler! implementation, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9) -> Avatars.MethodInvocation!
 static Avatars.MethodInvocation.Create<T1, T2, T3, T4, T5, T6, T7, T8, T9>(object! target, System.Reflection.MethodBase! method, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9) -> Avatars.MethodInvocation!
-static Avatars.MethodInvocation.Create<T1, T2, T3, T4, T5, T6, T7, T8>(object! target, System.Reflection.MethodBase! method, Avatars.ExecuteHandler! callBase, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8) -> Avatars.MethodInvocation!
+static Avatars.MethodInvocation.Create<T1, T2, T3, T4, T5, T6, T7, T8>(object! target, System.Reflection.MethodBase! method, Avatars.ExecuteHandler! implementation, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8) -> Avatars.MethodInvocation!
 static Avatars.MethodInvocation.Create<T1, T2, T3, T4, T5, T6, T7, T8>(object! target, System.Reflection.MethodBase! method, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8) -> Avatars.MethodInvocation!
-static Avatars.MethodInvocation.Create<T1, T2, T3, T4, T5, T6, T7>(object! target, System.Reflection.MethodBase! method, Avatars.ExecuteHandler! callBase, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7) -> Avatars.MethodInvocation!
+static Avatars.MethodInvocation.Create<T1, T2, T3, T4, T5, T6, T7>(object! target, System.Reflection.MethodBase! method, Avatars.ExecuteHandler! implementation, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7) -> Avatars.MethodInvocation!
 static Avatars.MethodInvocation.Create<T1, T2, T3, T4, T5, T6, T7>(object! target, System.Reflection.MethodBase! method, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7) -> Avatars.MethodInvocation!
-static Avatars.MethodInvocation.Create<T1, T2, T3, T4, T5, T6>(object! target, System.Reflection.MethodBase! method, Avatars.ExecuteHandler! callBase, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6) -> Avatars.MethodInvocation!
+static Avatars.MethodInvocation.Create<T1, T2, T3, T4, T5, T6>(object! target, System.Reflection.MethodBase! method, Avatars.ExecuteHandler! implementation, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6) -> Avatars.MethodInvocation!
 static Avatars.MethodInvocation.Create<T1, T2, T3, T4, T5, T6>(object! target, System.Reflection.MethodBase! method, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6) -> Avatars.MethodInvocation!
-static Avatars.MethodInvocation.Create<T1, T2, T3, T4, T5>(object! target, System.Reflection.MethodBase! method, Avatars.ExecuteHandler! callBase, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5) -> Avatars.MethodInvocation!
+static Avatars.MethodInvocation.Create<T1, T2, T3, T4, T5>(object! target, System.Reflection.MethodBase! method, Avatars.ExecuteHandler! implementation, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5) -> Avatars.MethodInvocation!
 static Avatars.MethodInvocation.Create<T1, T2, T3, T4, T5>(object! target, System.Reflection.MethodBase! method, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5) -> Avatars.MethodInvocation!
-static Avatars.MethodInvocation.Create<T1, T2, T3, T4>(object! target, System.Reflection.MethodBase! method, Avatars.ExecuteHandler! callBase, T1 arg1, T2 arg2, T3 arg3, T4 arg4) -> Avatars.MethodInvocation!
+static Avatars.MethodInvocation.Create<T1, T2, T3, T4>(object! target, System.Reflection.MethodBase! method, Avatars.ExecuteHandler! implementation, T1 arg1, T2 arg2, T3 arg3, T4 arg4) -> Avatars.MethodInvocation!
 static Avatars.MethodInvocation.Create<T1, T2, T3, T4>(object! target, System.Reflection.MethodBase! method, T1 arg1, T2 arg2, T3 arg3, T4 arg4) -> Avatars.MethodInvocation!
-static Avatars.MethodInvocation.Create<T1, T2, T3>(object! target, System.Reflection.MethodBase! method, Avatars.ExecuteHandler! callBase, T1 arg1, T2 arg2, T3 arg3) -> Avatars.MethodInvocation!
+static Avatars.MethodInvocation.Create<T1, T2, T3>(object! target, System.Reflection.MethodBase! method, Avatars.ExecuteHandler! implementation, T1 arg1, T2 arg2, T3 arg3) -> Avatars.MethodInvocation!
 static Avatars.MethodInvocation.Create<T1, T2, T3>(object! target, System.Reflection.MethodBase! method, T1 arg1, T2 arg2, T3 arg3) -> Avatars.MethodInvocation!
-static Avatars.MethodInvocation.Create<T1, T2>(object! target, System.Reflection.MethodBase! method, Avatars.ExecuteHandler! callBase, T1 arg1, T2 arg2) -> Avatars.MethodInvocation!
+static Avatars.MethodInvocation.Create<T1, T2>(object! target, System.Reflection.MethodBase! method, Avatars.ExecuteHandler! implementation, T1 arg1, T2 arg2) -> Avatars.MethodInvocation!
 static Avatars.MethodInvocation.Create<T1, T2>(object! target, System.Reflection.MethodBase! method, T1 arg1, T2 arg2) -> Avatars.MethodInvocation!
-static Avatars.MethodInvocation.Create<T>(object! target, System.Reflection.MethodBase! method, Avatars.ExecuteHandler! callBase, T arg) -> Avatars.MethodInvocation!
+static Avatars.MethodInvocation.Create<T>(object! target, System.Reflection.MethodBase! method, Avatars.ExecuteHandler! implementation, T arg) -> Avatars.MethodInvocation!
 static Avatars.MethodInvocation.Create<T>(object! target, System.Reflection.MethodBase! method, T arg) -> Avatars.MethodInvocation!
 static Avatars.MethodInvocationExtensions.CreateReturn(this Avatars.IMethodInvocation! invocation) -> Avatars.IMethodReturn!
 static Avatars.MethodInvocationExtensions.CreateReturn<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(this Avatars.IMethodInvocation! invocation, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15, T16 arg16) -> Avatars.IMethodReturn!

--- a/src/Avatar/Resources.resx
+++ b/src/Avatar/Resources.resx
@@ -150,14 +150,11 @@
   <data name="ArgumentsMismatch" xml:space="preserve">
     <value>The number of argument values does not match the number of parameters.</value>
   </data>
-  <data name="CallBaseNotImplemented" xml:space="preserve">
-    <value>Member {method} does not have a base implementation to call.</value>
+  <data name="NotImplemented" xml:space="preserve">
+    <value>Member {method} does not have an implementation.</value>
   </data>
-  <data name="CallBaseGetNextNotSupported" xml:space="preserve">
-    <value>Getting the next behavior from the base method call is not supported.</value>
-  </data>
-  <data name="PipelineNotImplemented" xml:space="preserve">
-    <value>No implementation found for {method}.</value>
+  <data name="GetNextNotSupported" xml:space="preserve">
+    <value>Getting the next behavior from a method implementation is not supported.</value>
   </data>
   <data name="TypeNotCompatible" xml:space="preserve">
     <value>Argument type '{argType}' is not compatible with its parameter '{paramType} {paramName}'.</value>


### PR DESCRIPTION
In preparation for adding decorator support, it's becoming clearer that that callBase delegate is actually the implementation of a method, be it from a call to the base implementation in a virtual method or the invocation of a target object provided as the instance being decorated for an interface avatar.

In order to avoid having two distinct concepts for the same idea (i.e. in IMethodInvocation we have a CreateCallBaseReturn), rename things consistently so we only talk about the ultimate implementation of the method, so, HasImplementation and CreateInvokeReturn (to invoke that implementation).

When we introduce decorators, we will not need to add additional public API members in the pipeline for that.

Fixes #108.