### PR TITLE
🔄 dotnet-file sync

### DIFF
--- a/.github/workflows/dotnet-file.yml
+++ b/.github/workflows/dotnet-file.yml
@@ -11,7 +11,7 @@ env:
   GH_TOKEN: ${{ secrets.GH_TOKEN }}
 
 jobs:
-  changelog:
+  sync:
     runs-on: windows-latest
     steps:
       - name: 🔍 GH_TOKEN

--- a/.netconfig
+++ b/.netconfig
@@ -106,8 +106,8 @@
 
 [file "src/Directory.Build.targets"]
 	url = https://github.com/devlooped/oss/blob/main/src/Directory.Build.targets
-	sha = d8ce9990d269b7af8a96193691c7a754d74c3dca
-	etag = f90be354c63f82bcfac68246648aee9a5a2842f1e4b66421b850939635610532
+	sha = 6edd918283051b5179f6255556d254654acc5b8c
+	etag = af2cf67157f42ab43a0082cbf876aa4cc46e167e6e6df6c05e9aaf36ffb23cc8
 	weak
 
 [file "src/kzu.snk"]
@@ -190,6 +190,6 @@
 
 [file ".github/workflows/dotnet-file.yml"]
 	url = https://github.com/devlooped/oss/blob/main/.github/workflows/dotnet-file.yml
-	sha = e977ded975b1a536e76d5577a15a8512570ad8c7
-	etag = a84e35210d22591f420ba49ffed469e23107fbccb685857a20188134026d91bd
+	sha = 99c4bb740c516bd2953464f4fdbfa32bcbde6352
+	etag = 9a04b2aa64b7f5b1d4a246908337a86c69e2124a61cfd7c198c8979d1a76bfa1
 	weak

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -33,11 +33,6 @@
     <OutDir>$(OutputPath)</OutDir>
   </PropertyGroup>
 
-  <PropertyGroup>
-    <!-- Define constant for TF like NET5, NET472, NETSTANDARD2, NETSTANDARD21 -->
-    <DefineConstants Condition="'$(TargetFramework)' != '' and '$(TargetFrameworks)' != ''">$(DefineConstants);$(TargetFramework.ToUpperInvariant().TrimEnd('0').TrimEnd('.').Replace('.', ''))</DefineConstants>
-  </PropertyGroup>
-
   <ItemGroup>
     <!-- Consider the project out of date if any of these files changes -->
     <UpToDateCheck Include="@(PackageFile);@(None);@(Content);@(EmbeddedResource)" />


### PR DESCRIPTION
# devlooped/oss

- Rename changelog to sync [devlooped/oss@99c4bb7](https://github.com/devlooped/oss/commit/99c4bb740c516bd2953464f4fdbfa32bcbde6352)
- Define target framework constant always, not only for multi-targeting [devlooped/oss@872f3ab](https://github.com/devlooped/oss/commit/872f3ab674ed375636eab6a34ae5d38426012ace)
- Remove DefineConstant since .NET5 SDK already provides them [devlooped/oss@6edd918](https://github.com/devlooped/oss/commit/6edd918283051b5179f6255556d254654acc5b8c)