### PR TITLE
🔄 dotnet-file sync

### DIFF
--- a/.github/workflows/dotnet-file.yml
+++ b/.github/workflows/dotnet-file.yml
@@ -34,7 +34,7 @@ jobs:
           dotnet gcm store --protocol=https --host=github.com --username=$env:GITHUB_ACTOR --password=$env:GH_TOKEN
           gh auth status
 
-          dotnet tool update -g dotnet-file --no-cache --add-source https://pkg.kzu.io/index.json --version 42.42.42-main.75
+          dotnet tool update -g dotnet-file
           dotnet file sync -c:$env:TEMP\dotnet-file.md
           if (test-path $env:TEMP\dotnet-file.md) {
             echo 'CHANGES<<EOF' >> $env:GITHUB_ENV
@@ -50,9 +50,9 @@ jobs:
         with:
           base: main
           branch: dotnet-file-sync
-          commit-message: 🔄 dotnet-file sync
+          commit-message: Bump files with dotnet-file sync
           
             ${{ env.CHANGES }}
-          title: "🔄 dotnet-file sync"
+          title: "Bump files with dotnet-file sync"
           body: ${{ env.CHANGES }}
           token: ${{ env.GH_TOKEN }}

--- a/.github/workflows/sponsors.ps1
+++ b/.github/workflows/sponsors.ps1
@@ -5,6 +5,8 @@ if ($author -eq $null) {
     throw 'No user id found'
 }
 
+gh auth status
+
 echo "Looking up sponsorship from $env:GITHUB_ACTOR ..."
 
 $query = gh api graphql --paginate -f owner='devlooped' -f query='

--- a/.netconfig
+++ b/.netconfig
@@ -130,8 +130,8 @@
 
 [file ".github/workflows/sponsors.ps1"]
 	url = https://github.com/devlooped/.github/blob/main/.github/workflows/sponsors.ps1
-	sha = ffde0b030405ef9925309cf69467570c75b6edea
-	etag = 5e29155d35ab142150e900df391363e03e5a15a8be46e4adeeb4c6fd34013289
+	sha = 11f5c27cfdb304436ef0b7ee27ff333cda31ef65
+	etag = 57a303125f3367b68ad0700d89ff4ba57cb29b33b303903488c9c8638d0bf735
 	weak
 
 [file "Gemfile"]
@@ -190,6 +190,6 @@
 
 [file ".github/workflows/dotnet-file.yml"]
 	url = https://github.com/devlooped/oss/blob/main/.github/workflows/dotnet-file.yml
-	sha = 99c4bb740c516bd2953464f4fdbfa32bcbde6352
-	etag = 9a04b2aa64b7f5b1d4a246908337a86c69e2124a61cfd7c198c8979d1a76bfa1
+	sha = 094043587f7e7313a0a77dece1532fbcb1ce8555
+	etag = 15333d15756257ec2d7975ea3ba5a22d1e3fae98aab35d83d67a728628e90cea
 	weak


### PR DESCRIPTION
# devlooped/oss

- Update to public stable version of dotnet-file [devlooped/oss@3e86410](https://github.com/devlooped/oss/commit/3e864109790fc5c4a42edc106d9dd3ad4b204973)
- Use "Bump" in commit text, unifies with dependabot [devlooped/oss@0940435](https://github.com/devlooped/oss/commit/094043587f7e7313a0a77dece1532fbcb1ce8555)

# devlooped/.github

- :lock: Show gh auth status before running sponsors query [devlooped/.github@11f5c27](https://github.com/devlooped/.github/commit/11f5c27cfdb304436ef0b7ee27ff333cda31ef65)