### PR TITLE
👀 Fail if no visible constructors available

### DIFF
--- a/src/Avatar.CodeAnalysis/AvatarDiagnostics.cs
+++ b/src/Avatar.CodeAnalysis/AvatarDiagnostics.cs
@@ -74,5 +74,18 @@ namespace Avatars.CodeAnalysis
             DiagnosticSeverity.Error,
             true,
             Strings.PointerMember.Description);
+
+        /// <summary>
+        /// Diagnostic reported whenever the specified base type for a 
+        /// <see cref="AvatarGeneratorAttribute"/>-annotated method is sealed.
+        /// </summary>
+        public static DiagnosticDescriptor BaseTypeNoContructor { get; } = new DiagnosticDescriptor(
+            "ST006",
+            Strings.BaseTypeNoCtor.Title,
+            Resources.BaseTypeNoCtor_Message,
+            "Build",
+            DiagnosticSeverity.Error,
+            true,
+            Strings.BaseTypeNoCtor.Description);
     }
 }

--- a/src/Avatar.CodeAnalysis/AvatarDiagnostics.cs
+++ b/src/Avatar.CodeAnalysis/AvatarDiagnostics.cs
@@ -15,7 +15,7 @@ namespace Avatars.CodeAnalysis
         /// the compiler requirement of having the base class as the first type too.
         /// </summary>
         public static DiagnosticDescriptor BaseTypeNotFirst { get; } = new DiagnosticDescriptor(
-            "ST001",
+            "AVTR001",
             nameof(Strings.BaseTypeNotFirst.Title),
             Resources.BaseTypeNotFirst_Message,
             "Build",
@@ -28,7 +28,7 @@ namespace Avatars.CodeAnalysis
         /// <see cref="AvatarGeneratorAttribute"/>-annotated method is duplicated.
         /// </summary>
         public static DiagnosticDescriptor DuplicateBaseType { get; } = new DiagnosticDescriptor(
-            "ST002",
+            "AVTR002",
             Strings.DuplicateBaseType.Title,
             Resources.DuplicateBaseType_Message,
             "Build",
@@ -41,7 +41,7 @@ namespace Avatars.CodeAnalysis
         /// <see cref="AvatarGeneratorAttribute"/>-annotated method is sealed.
         /// </summary>
         public static DiagnosticDescriptor SealedBaseType { get; } = new DiagnosticDescriptor(
-            "ST003",
+            "AVTR003",
             Strings.SealedBaseType.Title,
             Resources.SealedBaseType_Message,
             "Build",
@@ -54,7 +54,7 @@ namespace Avatars.CodeAnalysis
         /// <see cref="AvatarGeneratorAttribute"/>-annotated method is an enum.
         /// </summary>
         public static DiagnosticDescriptor EnumType { get; } = new DiagnosticDescriptor(
-            "ST004",
+            "AVTR004",
             Strings.EnumType.Title,
             Resources.EnumType_Message,
             "Build",
@@ -67,7 +67,7 @@ namespace Avatars.CodeAnalysis
         /// pointer type arguments, which are unsupported at the moment.
         /// </summary>
         public static DiagnosticDescriptor PointerMember { get; } = new DiagnosticDescriptor(
-            "ST005",
+            "AVTR005",
             Strings.PointerMember.Title,
             Resources.PointerMember_Message,
             "Build",
@@ -80,7 +80,7 @@ namespace Avatars.CodeAnalysis
         /// <see cref="AvatarGeneratorAttribute"/>-annotated method is sealed.
         /// </summary>
         public static DiagnosticDescriptor BaseTypeNoContructor { get; } = new DiagnosticDescriptor(
-            "ST006",
+            "AVTR006",
             Strings.BaseTypeNoCtor.Title,
             Resources.BaseTypeNoCtor_Message,
             "Build",

--- a/src/Avatar.CodeAnalysis/Resources.Designer.cs
+++ b/src/Avatar.CodeAnalysis/Resources.Designer.cs
@@ -61,6 +61,33 @@ namespace Avatars {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Base type has no accessible constructors..
+        /// </summary>
+        internal static string BaseTypeNoCtor_Description {
+            get {
+                return ResourceManager.GetString("BaseTypeNoCtor_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Cannot specify base type &apos;{0}&apos; because it has no public or protected constructors..
+        /// </summary>
+        internal static string BaseTypeNoCtor_Message {
+            get {
+                return ResourceManager.GetString("BaseTypeNoCtor_Message", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Invalid base type.
+        /// </summary>
+        internal static string BaseTypeNoCtor_Title {
+            get {
+                return ResourceManager.GetString("BaseTypeNoCtor_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to When a base type is specified, it must be the first type in the type arguments list..
         /// </summary>
         internal static string BaseTypeNotFirst_Description {
@@ -124,7 +151,7 @@ namespace Avatars {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Cannot specify enum type &apos;{0}&apos;...
+        ///   Looks up a localized string similar to Cannot specify enum type &apos;{0}&apos;..
         /// </summary>
         internal static string EnumType_Message {
             get {
@@ -169,7 +196,7 @@ namespace Avatars {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Cannot generate code for nested types yet: {0}.
+        ///   Looks up a localized string similar to Cannot generate code for nested types yet: {0}..
         /// </summary>
         internal static string NestedType_Message {
             get {
@@ -196,7 +223,7 @@ namespace Avatars {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Cannot generate code for types containing members that use pointer types yet: {0}.
+        ///   Looks up a localized string similar to Cannot generate code for types containing members that use pointer types yet: {0}..
         /// </summary>
         internal static string PointerMember_Message {
             get {
@@ -223,7 +250,7 @@ namespace Avatars {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Cannot specify sealed base type &apos;{0}&apos;...
+        ///   Looks up a localized string similar to Cannot specify sealed base type &apos;{0}&apos;..
         /// </summary>
         internal static string SealedBaseType_Message {
             get {

--- a/src/Avatar.CodeAnalysis/Resources.resx
+++ b/src/Avatar.CodeAnalysis/Resources.resx
@@ -145,7 +145,7 @@
     <value>Nested types are not supported yet.</value>
   </data>
   <data name="NestedType_Message" xml:space="preserve">
-    <value>Cannot generate code for nested types yet: {0}</value>
+    <value>Cannot generate code for nested types yet: {0}.</value>
   </data>
   <data name="NestedType_Title" xml:space="preserve">
     <value>Nested types not supported</value>
@@ -154,7 +154,7 @@
     <value>Types containing members that use pointer types are not supported yet.</value>
   </data>
   <data name="PointerMember_Message" xml:space="preserve">
-    <value>Cannot generate code for types containing members that use pointer types yet: {0}</value>
+    <value>Cannot generate code for types containing members that use pointer types yet: {0}.</value>
   </data>
   <data name="PointerMember_Title" xml:space="preserve">
     <value>Types using pointer parameters are not supported</value>
@@ -163,7 +163,7 @@
     <value>Cannot specify sealed base type.</value>
   </data>
   <data name="SealedBaseType_Message" xml:space="preserve">
-    <value>Cannot specify sealed base type '{0}'..</value>
+    <value>Cannot specify sealed base type '{0}'.</value>
   </data>
   <data name="SealedBaseType_Title" xml:space="preserve">
     <value>Invalid sealed base type</value>
@@ -178,9 +178,18 @@
     <value>Cannot specify an enum base type.</value>
   </data>
   <data name="EnumType_Message" xml:space="preserve">
-    <value>Cannot specify enum type '{0}'..</value>
+    <value>Cannot specify enum type '{0}'.</value>
   </data>
   <data name="EnumType_Title" xml:space="preserve">
     <value>Invalid enum base type</value>
+  </data>
+  <data name="BaseTypeNoCtor_Description" xml:space="preserve">
+    <value>Base type has no accessible constructors.</value>
+  </data>
+  <data name="BaseTypeNoCtor_Message" xml:space="preserve">
+    <value>Cannot specify base type '{0}' because it has no public or protected constructors.</value>
+  </data>
+  <data name="BaseTypeNoCtor_Title" xml:space="preserve">
+    <value>Invalid base type</value>
   </data>
 </root>

--- a/src/Avatar.StaticProxy/IAvatarCandidatesReceiver.cs
+++ b/src/Avatar.StaticProxy/IAvatarCandidatesReceiver.cs
@@ -17,6 +17,11 @@ namespace Avatars
         /// (interface or base class) plus any extra interfaces to implement for it. 
         /// </summary>
         /// <param name="context">The current generation context, from which the compilation and symbols can be resolved.</param>
-        IEnumerable<INamedTypeSymbol[]> GetCandidates(ProcessorContext context);
+        /// <returns>
+        /// A tuple of the <see cref="SyntaxNode"/> that caused the nomination of a candidate 
+        /// for avatar generation, and the array of <see cref="INamedTypeSymbol"/> symbols in 
+        /// use at that location.
+        /// </returns>
+        IEnumerable<(SyntaxNode source, INamedTypeSymbol[] candidate)> GetCandidates(ProcessorContext context);
     }
 }

--- a/src/Avatar.StaticProxy/OverridableMembersAnalyzer.cs
+++ b/src/Avatar.StaticProxy/OverridableMembersAnalyzer.cs
@@ -16,9 +16,9 @@ namespace Avatars
     public class OverridableMembersAnalyzer : DiagnosticAnalyzer
     {
         /// <summary>
-        /// The diagnostics identifier exposed by this analyzer, <c>ST999</c>.
+        /// The diagnostics identifier exposed by this analyzer, <c>AVTR999</c>.
         /// </summary>
-        public const string DiagnosticId = "ST999";
+        public const string DiagnosticId = "AVTR999";
         /// <summary>
         /// The category for the diagnostics reported by this analyzer, <c>Build</c>.
         /// </summary>

--- a/src/Avatar.UnitTests/Avatar.UnitTests.csproj
+++ b/src/Avatar.UnitTests/Avatar.UnitTests.csproj
@@ -56,9 +56,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="CodeAnalysis\ST*\**\*.NoBuild.cs" CopyToOutputDirectory="PreserveNewest" />
-    <Compile Remove="CodeAnalysis\ST*\**\*.NoBuild.cs" />
-    <Compile Update="CodeAnalysis\ST*\**\*.cs" CopyToOutputDirectory="PreserveNewest" />
+    <None Include="CodeAnalysis\AVTR*\**\*.NoBuild.cs" CopyToOutputDirectory="PreserveNewest" />
+    <Compile Remove="CodeAnalysis\AVTR*\**\*.NoBuild.cs" />
+    <Compile Update="CodeAnalysis\AVTR*\**\*.cs" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
   <ItemGroup>
@@ -82,8 +82,8 @@
       <ThisAssemblySourcesDirectory>$(MSBuildProjectDirectory)\$(OutputPath)</ThisAssemblySourcesDirectory>
     </PropertyGroup>
     <ItemGroup>
-      <FileConstant Include="@(Compile)" Condition="$([MSBuild]::ValueOrDefault('%(RelativeDir)', '').StartsWith('CodeAnalysis\ST'))" />
-      <FileConstant Include="@(Compile)" Condition="$([MSBuild]::ValueOrDefault('%(RelativeDir)', '').StartsWith('CodeAnalysis/ST'))" />
+      <FileConstant Include="@(Compile)" Condition="$([MSBuild]::ValueOrDefault('%(RelativeDir)', '').StartsWith('CodeAnalysis\AVTR'))" />
+      <FileConstant Include="@(Compile)" Condition="$([MSBuild]::ValueOrDefault('%(RelativeDir)', '').StartsWith('CodeAnalysis/AVTR'))" />
       <FileConstant Include="@(Compile)" Condition="$([MSBuild]::ValueOrDefault('%(RelativeDir)', '').StartsWith('Scenarios'))" />
     </ItemGroup>
   </Target>

--- a/src/Avatar.UnitTests/CodeAnalysis/AVTR001/Diagnostic/PublicClass.cs
+++ b/src/Avatar.UnitTests/CodeAnalysis/AVTR001/Diagnostic/PublicClass.cs
@@ -1,14 +1,16 @@
 ﻿using System;
 
-namespace Avatars.UnitTests.CodeAnalysis.ST004.Diagnostic
+namespace Avatars.UnitTests.CodeAnalysis.AVTR001.Diagnostic
 {
     public partial class MyClass
     {
         public MyClass()
         {
-            var avatar = Avatar.Of<PlatformID>();
+            var avatar = Avatar.Of<IDisposable, BaseType>();
 
             Console.WriteLine(avatar);
         }
     }
+
+    public class BaseType { }
 }

--- a/src/Avatar.UnitTests/CodeAnalysis/AVTR001_BaseTypeNotFist.cs
+++ b/src/Avatar.UnitTests/CodeAnalysis/AVTR001_BaseTypeNotFist.cs
@@ -6,18 +6,18 @@ using Xunit;
 
 namespace Avatars.UnitTests
 {
-    public class ST002_DuplicateBaseType : DiagnosticVerifier
+    public class AVTR001_BaseTypeNotFist : DiagnosticVerifier
     {
         protected override DiagnosticAnalyzer? GetCSharpDiagnosticAnalyzer() => new ValidateTypesAnalyzer();
 
         [Theory]
-        [InlineData(ThisAssembly.Constants.CodeAnalysis.ST002.Diagnostic.PublicClass, 9, 26)]
+        [InlineData(ThisAssembly.Constants.CodeAnalysis.AVTR001.Diagnostic.PublicClass, 9, 26)]
         public void Verify_Diagnostic(string path, int line, int column)
         {
             var expected = new DiagnosticResult
             {
-                Id = AvatarDiagnostics.DuplicateBaseType.Id,
-                Message = Resources.DuplicateBaseType_Message,
+                Id = AvatarDiagnostics.BaseTypeNotFirst.Id,
+                Message = string.Format(Resources.BaseTypeNotFirst_Message, "BaseType"),
                 Severity = DiagnosticSeverity.Error,
                 Locations = new[] {
                     new DiagnosticResultLocation("Test0.cs", line, column)

--- a/src/Avatar.UnitTests/CodeAnalysis/AVTR002/Diagnostic/PublicClass.cs
+++ b/src/Avatar.UnitTests/CodeAnalysis/AVTR002/Diagnostic/PublicClass.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace Avatars.UnitTests.CodeAnalysis.ST002.Diagnostic
+namespace Avatars.UnitTests.CodeAnalysis.AVTR002.Diagnostic
 {
     public partial class MyClass
     {

--- a/src/Avatar.UnitTests/CodeAnalysis/AVTR002_DuplicateBaseType.cs
+++ b/src/Avatar.UnitTests/CodeAnalysis/AVTR002_DuplicateBaseType.cs
@@ -6,18 +6,18 @@ using Xunit;
 
 namespace Avatars.UnitTests
 {
-    public class ST001_BaseTypeNotFist : DiagnosticVerifier
+    public class AVTR002_DuplicateBaseType : DiagnosticVerifier
     {
         protected override DiagnosticAnalyzer? GetCSharpDiagnosticAnalyzer() => new ValidateTypesAnalyzer();
 
         [Theory]
-        [InlineData(ThisAssembly.Constants.CodeAnalysis.ST001.Diagnostic.PublicClass, 9, 26)]
+        [InlineData(ThisAssembly.Constants.CodeAnalysis.AVTR002.Diagnostic.PublicClass, 9, 26)]
         public void Verify_Diagnostic(string path, int line, int column)
         {
             var expected = new DiagnosticResult
             {
-                Id = AvatarDiagnostics.BaseTypeNotFirst.Id,
-                Message = string.Format(Resources.BaseTypeNotFirst_Message, "BaseType"),
+                Id = AvatarDiagnostics.DuplicateBaseType.Id,
+                Message = Resources.DuplicateBaseType_Message,
                 Severity = DiagnosticSeverity.Error,
                 Locations = new[] {
                     new DiagnosticResultLocation("Test0.cs", line, column)

--- a/src/Avatar.UnitTests/CodeAnalysis/AVTR003/Diagnostic/PublicClass.cs
+++ b/src/Avatar.UnitTests/CodeAnalysis/AVTR003/Diagnostic/PublicClass.cs
@@ -1,16 +1,16 @@
 ﻿using System;
 
-namespace Avatars.UnitTests.CodeAnalysis.ST001.Diagnostic
+namespace Avatars.UnitTests.CodeAnalysis.AVTR003.Diagnostic
 {
     public partial class MyClass
     {
         public MyClass()
         {
-            var avatar = Avatar.Of<IDisposable, BaseType>();
+            var avatar = Avatar.Of<BaseType>();
 
             Console.WriteLine(avatar);
         }
     }
 
-    public class BaseType { }
+    public sealed class BaseType { }
 }

--- a/src/Avatar.UnitTests/CodeAnalysis/AVTR003_SealedBaseType.cs
+++ b/src/Avatar.UnitTests/CodeAnalysis/AVTR003_SealedBaseType.cs
@@ -6,18 +6,18 @@ using Xunit;
 
 namespace Avatars.UnitTests
 {
-    public class ST005_PointerMember : DiagnosticVerifier
+    public class AVTR003_SealedBaseType : DiagnosticVerifier
     {
-        protected override DiagnosticAnalyzer? GetCSharpDiagnosticAnalyzer() => new PointerMemberAnalyzer();
+        protected override DiagnosticAnalyzer? GetCSharpDiagnosticAnalyzer() => new ValidateTypesAnalyzer();
 
         [Theory]
-        [InlineData(ThisAssembly.Constants.CodeAnalysis.ST005.Diagnostic.PublicClass, 9, 26)]
+        [InlineData(ThisAssembly.Constants.CodeAnalysis.AVTR003.Diagnostic.PublicClass, 9, 26)]
         public void Verify_Diagnostic(string path, int line, int column)
         {
             var expected = new DiagnosticResult
             {
-                Id = AvatarDiagnostics.PointerMember.Id,
-                Message = string.Format(Resources.PointerMember_Message, "IPointers"),
+                Id = AvatarDiagnostics.SealedBaseType.Id,
+                Message = string.Format(Resources.SealedBaseType_Message, "BaseType"),
                 Severity = DiagnosticSeverity.Error,
                 Locations = new[] {
                     new DiagnosticResultLocation("Test0.cs", line, column)

--- a/src/Avatar.UnitTests/CodeAnalysis/AVTR004/Diagnostic/MultipleEnums.cs
+++ b/src/Avatar.UnitTests/CodeAnalysis/AVTR004/Diagnostic/MultipleEnums.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace Avatars.UnitTests.CodeAnalysis.ST004.Diagnostic
+namespace Avatars.UnitTests.CodeAnalysis.AVTR004.Diagnostic
 {
     public partial class MultipleEnums
     {

--- a/src/Avatar.UnitTests/CodeAnalysis/AVTR004/Diagnostic/PublicClass.cs
+++ b/src/Avatar.UnitTests/CodeAnalysis/AVTR004/Diagnostic/PublicClass.cs
@@ -1,16 +1,14 @@
 ﻿using System;
 
-namespace Avatars.UnitTests.CodeAnalysis.ST003.Diagnostic
+namespace Avatars.UnitTests.CodeAnalysis.AVTR004.Diagnostic
 {
     public partial class MyClass
     {
         public MyClass()
         {
-            var avatar = Avatar.Of<BaseType>();
+            var avatar = Avatar.Of<PlatformID>();
 
             Console.WriteLine(avatar);
         }
     }
-
-    public sealed class BaseType { }
 }

--- a/src/Avatar.UnitTests/CodeAnalysis/AVTR004_EnumType.cs
+++ b/src/Avatar.UnitTests/CodeAnalysis/AVTR004_EnumType.cs
@@ -6,7 +6,7 @@ using Xunit;
 
 namespace Avatars.UnitTests
 {
-    public class ST004_EnumType : DiagnosticVerifier
+    public class AVTR004_EnumType : DiagnosticVerifier
     {
         protected override DiagnosticAnalyzer? GetCSharpDiagnosticAnalyzer() => new ValidateTypesAnalyzer();
 
@@ -16,7 +16,7 @@ namespace Avatars.UnitTests
             VerifyCSharpDiagnostic(
                 new[]
                 {
-                    File.ReadAllText(ThisAssembly.Constants.CodeAnalysis.ST004.Diagnostic.MultipleEnums),
+                    File.ReadAllText(ThisAssembly.Constants.CodeAnalysis.AVTR004.Diagnostic.MultipleEnums),
                     File.ReadAllText(@"Avatar/Avatar.cs"),
                 },
                 new[]
@@ -43,7 +43,7 @@ namespace Avatars.UnitTests
         }
 
         [Theory]
-        [InlineData(ThisAssembly.Constants.CodeAnalysis.ST004.Diagnostic.PublicClass, 9, 26)]
+        [InlineData(ThisAssembly.Constants.CodeAnalysis.AVTR004.Diagnostic.PublicClass, 9, 26)]
         public void Verify_Diagnostic(string path, int line, int column)
         {
             var expected = new DiagnosticResult

--- a/src/Avatar.UnitTests/CodeAnalysis/AVTR005/Diagnostic/PublicClass.cs
+++ b/src/Avatar.UnitTests/CodeAnalysis/AVTR005/Diagnostic/PublicClass.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace Avatars.UnitTests.CodeAnalysis.ST005.Diagnostic
+namespace Avatars.UnitTests.CodeAnalysis.AVTR005.Diagnostic
 {
     public partial class MyClass
     {

--- a/src/Avatar.UnitTests/CodeAnalysis/AVTR005_PointerMember.cs
+++ b/src/Avatar.UnitTests/CodeAnalysis/AVTR005_PointerMember.cs
@@ -6,18 +6,18 @@ using Xunit;
 
 namespace Avatars.UnitTests
 {
-    public class ST003_SealedBaseType : DiagnosticVerifier
+    public class AVTR005_PointerMember : DiagnosticVerifier
     {
-        protected override DiagnosticAnalyzer? GetCSharpDiagnosticAnalyzer() => new ValidateTypesAnalyzer();
+        protected override DiagnosticAnalyzer? GetCSharpDiagnosticAnalyzer() => new PointerMemberAnalyzer();
 
         [Theory]
-        [InlineData(ThisAssembly.Constants.CodeAnalysis.ST003.Diagnostic.PublicClass, 9, 26)]
+        [InlineData(ThisAssembly.Constants.CodeAnalysis.AVTR005.Diagnostic.PublicClass, 9, 26)]
         public void Verify_Diagnostic(string path, int line, int column)
         {
             var expected = new DiagnosticResult
             {
-                Id = AvatarDiagnostics.SealedBaseType.Id,
-                Message = string.Format(Resources.SealedBaseType_Message, "BaseType"),
+                Id = AvatarDiagnostics.PointerMember.Id,
+                Message = string.Format(Resources.PointerMember_Message, "IPointers"),
                 Severity = DiagnosticSeverity.Error,
                 Locations = new[] {
                     new DiagnosticResultLocation("Test0.cs", line, column)

--- a/src/Avatar.UnitTests/CodeAnalysis/AVTR999/Diagnostic/PublicClass.cs
+++ b/src/Avatar.UnitTests/CodeAnalysis/AVTR999/Diagnostic/PublicClass.cs
@@ -1,5 +1,5 @@
 ﻿#nullable disable
-namespace Avatars.UnitTests.CodeAnalysis.ST999.Diagnostic
+namespace Avatars.UnitTests.CodeAnalysis.AVTR999.Diagnostic
 {
     public partial class MyClass
     {

--- a/src/Avatar.UnitTests/CodeAnalysis/AVTR999/Diagnostic/PublicClassFix.cs
+++ b/src/Avatar.UnitTests/CodeAnalysis/AVTR999/Diagnostic/PublicClassFix.cs
@@ -1,5 +1,5 @@
 ﻿#nullable disable
-namespace Avatars.UnitTests.CodeAnalysis.ST999.Diagnostic
+namespace Avatars.UnitTests.CodeAnalysis.AVTR999.Diagnostic
 {
     public partial class MyClass
     {

--- a/src/Avatar.UnitTests/CodeAnalysis/AVTR999_OverridableMembers.cs
+++ b/src/Avatar.UnitTests/CodeAnalysis/AVTR999_OverridableMembers.cs
@@ -1,26 +1,21 @@
 ﻿using System.IO;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Xunit;
 
 namespace Avatars.UnitTests
 {
-    public class ST999_OverrideAllMembers : CodeFixVerifier
+    public class AVTR999_OverridableMembers : DiagnosticVerifier
     {
         protected override DiagnosticAnalyzer? GetCSharpDiagnosticAnalyzer() => new OverridableMembersAnalyzer();
 
-        protected override CodeFixProvider? GetCSharpCodeFixProvider() => new OverrideAllMembersCodeFix();
-
         [Theory]
-        [InlineData(
-            ThisAssembly.Constants.CodeAnalysis.ST999.Diagnostic.PublicClass,
-            ThisAssembly.Constants.CodeAnalysis.ST999.Diagnostic.PublicClassFix, 4, 26)]
-        public void Verify_Diagnostic(string path, string fix, int line, int column)
+        [InlineData(ThisAssembly.Constants.CodeAnalysis.AVTR999.Diagnostic.PublicClass, 4, 26)]
+        public void Verify_Diagnostic(string path, int line, int column)
         {
             var expected = new DiagnosticResult
             {
-                Id = nameof(ThisAssembly.Constants.CodeAnalysis.ST999),
+                Id = "AVTR999",
                 Message = nameof(OverridableMembersAnalyzer),
                 Severity = DiagnosticSeverity.Hidden,
                 Locations = new[] {
@@ -31,10 +26,6 @@ namespace Avatars.UnitTests
             VerifyCSharpDiagnostic(
                 File.ReadAllText(path),
                 expected);
-
-            VerifyCSharpFix(
-                File.ReadAllText(path),
-                File.ReadAllText(fix));
         }
     }
 }

--- a/src/Avatar.UnitTests/CodeAnalysis/AVTR999_OverrideAllMembers.cs
+++ b/src/Avatar.UnitTests/CodeAnalysis/AVTR999_OverrideAllMembers.cs
@@ -1,21 +1,26 @@
 ﻿using System.IO;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Xunit;
 
 namespace Avatars.UnitTests
 {
-    public class ST999_OverridableMembers : DiagnosticVerifier
+    public class AVTR999_OverrideAllMembers : CodeFixVerifier
     {
         protected override DiagnosticAnalyzer? GetCSharpDiagnosticAnalyzer() => new OverridableMembersAnalyzer();
 
+        protected override CodeFixProvider? GetCSharpCodeFixProvider() => new OverrideAllMembersCodeFix();
+
         [Theory]
-        [InlineData(ThisAssembly.Constants.CodeAnalysis.ST999.Diagnostic.PublicClass, 4, 26)]
-        public void Verify_Diagnostic(string path, int line, int column)
+        [InlineData(
+            ThisAssembly.Constants.CodeAnalysis.AVTR999.Diagnostic.PublicClass,
+            ThisAssembly.Constants.CodeAnalysis.AVTR999.Diagnostic.PublicClassFix, 4, 26)]
+        public void Verify_Diagnostic(string path, string fix, int line, int column)
         {
             var expected = new DiagnosticResult
             {
-                Id = "ST999",
+                Id = nameof(ThisAssembly.Constants.CodeAnalysis.AVTR999),
                 Message = nameof(OverridableMembersAnalyzer),
                 Severity = DiagnosticSeverity.Hidden,
                 Locations = new[] {
@@ -26,6 +31,10 @@ namespace Avatars.UnitTests
             VerifyCSharpDiagnostic(
                 File.ReadAllText(path),
                 expected);
+
+            VerifyCSharpFix(
+                File.ReadAllText(path),
+                File.ReadAllText(fix));
         }
     }
 }


### PR DESCRIPTION
If target type has no accessible constructor, report an error
diagnostic when code is generated. Currently, we need to do this
from the actual generator since we scaffold all default ctors
from there and it's an easy spot to query for them.

An analyzer would need to actually inspect the base type and
determine if generation would succeed at all. That would be a
nice perf. improvement if easy to implement, but right now it
does not seem worth it given the way we currently rely on code
fixes to scaffold the basic code.

Fixes #129.