### PR TITLE
Update to latest NuGet protocol package

### DIFF
--- a/src/Avatar.IntegrationTests/Avatar.IntegrationTests.csproj
+++ b/src/Avatar.IntegrationTests/Avatar.IntegrationTests.csproj
@@ -26,7 +26,7 @@
 
     <PackageReference Include="Superpower" />
     <PackageReference Include="NuGet.Client" />
-    <PackageReference Include="NuGet.Protocol.Core.v3" />
+    <PackageReference Include="NuGet.Protocol" />
   </ItemGroup>
 
   <ItemGroup Label="Targets">

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -48,7 +48,7 @@
     <PackageVersion Include="System.ComponentModel.Composition" Version="5.0.0" />
 
     <PackageVersion Include="NuGet.Client" Version="4.2.0" />
-    <PackageVersion Include="NuGet.Protocol.Core.v3" Version="4.2.0" />
+    <PackageVersion Include="NuGet.Protocol" Version="5.9.0" />
   </ItemGroup>
 
   <ItemGroup Label="MSBuild">


### PR DESCRIPTION
The existing (now legacy) API was not returning the latest
prerelease package for some reason. The newer one returns
all entries as expected, so switch to that instead.

We also improve the output folder organization in the integration
test for internal access so that restoring one project does not
cause mismatched dependencies on another, since it seems otherwise
the project.assets.json ended up in the same location for all
projects, alongside the project file (which were previously all
at the same level).