### PR TITLE
Bump files with dotnet-file sync

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,6 +21,10 @@ jobs:
     steps:
       - name: 🤘 checkout
         uses: actions/checkout@v2
+        with: 
+          submodules: recursive
+          fetch-depth: 0
+
       - name: ✓ ensure format
         run: |
           dotnet tool update -g dotnet-format --version 5.0.*
@@ -50,21 +54,12 @@ jobs:
       - name: 📦 pack
         run: dotnet pack -m:1 -bl:pack.binlog -p:VersionLabel="$GITHUB_REF.$GITHUB_RUN_NUMBER" -p:RepositoryBranch=${GITHUB_REF#refs/*/}
 
-      - name: 🔼 logs
-        if: always()
-        uses: actions/upload-artifact@v2
-        with:
-          name: ${{ matrix.os }}
-          path: |
-            **/*.binlog
-            logs/**/*.*
-      
       - name: 🔼 packages
         uses: actions/upload-artifact@v2
         with:
           name: bin
           path: bin/*.nupkg
-
+      
       # Only push CI package to sleet feed if building on ubuntu (fastest)
       - name: 🚀 sleet
         env:
@@ -72,7 +67,7 @@ jobs:
         if: matrix.os == 'ubuntu-latest' && env.SLEET_CONNECTION != ''
         run: |
           dotnet tool install -g --version 4.0.18 sleet 
-          sleet push bin --config none -f --verbose -p "SLEET_FEED_CONTAINER=nuget" -p "SLEET_FEED_CONNECTIONSTRING=${{ secrets.SLEET_CONNECTION }}" -p "SLEET_FEED_TYPE=azure"
+          sleet push bin --config none -f --verbose -p "SLEET_FEED_CONTAINER=nuget" -p "SLEET_FEED_CONNECTIONSTRING=${{ secrets.SLEET_CONNECTION }}" -p "SLEET_FEED_TYPE=azure" || echo "No packages found"
 
   acceptance:
     name: acceptance-${{ matrix.os }}
@@ -92,15 +87,8 @@ jobs:
           path: bin
 
       - name: 🧪 test
-        run: dotnet test -p:VersionLabel="$GITHUB_REF.$GITHUB_RUN_NUMBER" -bl:acceptance.binlog
+        run: dotnet test -p:VersionLabel="$GITHUB_REF.$GITHUB_RUN_NUMBER"
         working-directory: src/Acceptance
-
-      - name: 🔼 logs
-        if: ${{ always() }}
-        uses: actions/upload-artifact@v2
-        with:
-          name: ${{ matrix.os }}
-          path: '**/*.binlog'
 
   preview:
     defaults:
@@ -126,7 +114,6 @@ jobs:
         run: |
           iwr -useb get.scoop.sh | iex
           scoop install curl
-
       - name: 🔍 status for PR
         if: ${{ github.event.pull_request.head.sha }}
         run: echo "STATUS_SHA=${{ github.event.pull_request.head.sha }}" >> $env:GITHUB_ENV
@@ -156,12 +143,5 @@ jobs:
           path: bin
 
       - name: 🧪 test
-        run: msbuild -r -t:build,test -p:TargetFramework=net472 -p:VersionLabel="$($env:GITHUB_REF).$($env:GITHUB_RUN_NUMBER)" -bl:preview.binlog
+        run: msbuild -r -t:build,test -p:TargetFramework=net472 -p:VersionLabel="$($env:GITHUB_REF).$($env:GITHUB_RUN_NUMBER)"
         working-directory: src/Acceptance
-
-      - name: 🔼 logs
-        if: ${{ always() }}
-        uses: actions/upload-artifact@v2
-        with:
-          name: windows-latest
-          path: '**/*.binlog'

--- a/.netconfig
+++ b/.netconfig
@@ -52,8 +52,8 @@
 
 [file ".github/workflows/build.yml"]
 	url = https://github.com/devlooped/oss/blob/main/.github/workflows/build.yml
-	sha = c2ad879554e326fbc80fa1bbdc2dbc22f53001e1
-	etag = 82a160cfc3042b7d277b13fe539b1f311a0afa264802d31330ac42b7beb37ae3
+	sha = 4bc9de2ce63f083c2805752a25c5997ebc102aeb
+	etag = 16edbc0d7121c2527f0e62d441bbb4ac2b1ffc7e25ccd4b3d0611c0c86716520
 	weak
 
 [file ".github_changelog_generator"]
@@ -100,14 +100,14 @@
 
 [file "src/Directory.Build.props"]
 	url = https://github.com/devlooped/oss/blob/main/src/Directory.Build.props
-	sha = 16ac2f336b14d6b340b10fa162242a9742eb08fc
-	etag = 16762b7a7fbdc00c1912c469962131c912856115826db7628167517eea918324
+	sha = c9924b558ddeafb2cb547a7fcbc18aa7ae292ad1
+	etag = dc86d6818b98a7426c604039a07e134d61c8c598f1ceedb9e0e481fa0f93385d
 	weak
 
 [file "src/Directory.Build.targets"]
 	url = https://github.com/devlooped/oss/blob/main/src/Directory.Build.targets
-	sha = 6edd918283051b5179f6255556d254654acc5b8c
-	etag = af2cf67157f42ab43a0082cbf876aa4cc46e167e6e6df6c05e9aaf36ffb23cc8
+	sha = e7de4d0e790f9fe58f31308f95886884b6c5805f
+	etag = 9956aef0f3becce22fc1dc4e68dd218d5ba3c23de2b106c4ad006ad321cacc4a
 	weak
 
 [file "src/kzu.snk"]

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -63,18 +63,6 @@
     <!-- We typically don't want these files shown in the solution explorer -->
     <DefaultItemExcludes>$(DefaultItemExcludes);*.binlog;*.zip;*.rsp;*.items;**/TestResults/**/*.*</DefaultItemExcludes>
 
-    <!-- We use a single oss signing key for consumers that need strong-named assemblies -->
-    <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)kzu.snk</AssemblyOriginatorKeyFile>
-    <!-- These properties make it easier to add internals visible to other projects, even when signing is involved.
-         For example, you can simply add: 
-          <InternalsVisibleTo Include="MyProject.UnitTests" />
-
-         and the key will be appended automatically.
-    -->
-    <PublicKey>002400000480000094000000060200000024000052534131000400000100010051155fd0ee280be78d81cc979423f1129ec5dd28edce9cd94fd679890639cad54c121ebdb606f8659659cd313d3b3db7fa41e2271158dd602bb0039a142717117fa1f63d93a2d288a1c2f920ec05c4858d344a45d48ebd31c1368ab783596b382b611d8c92f9c1b3d338296aa21b12f3bc9f34de87756100c172c52a24bad2db</PublicKey>
-    <PublicKeyToken>00352124762f2aa5</PublicKeyToken>
-    <SignAssembly>true</SignAssembly>
-
     <EnableSourceLink>true</EnableSourceLink>
     <EnableSourceControlManagerQueries>true</EnableSourceControlManagerQueries>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
@@ -90,6 +78,20 @@
     <NoWarn>NU5105;$(NoWarn)</NoWarn>
     <!-- Turn warnings into errors in CI or Release builds -->
     <WarningsAsErrors Condition="$(CI) or '$(Configuration)' == 'Release'">true</WarningsAsErrors>
+  </PropertyGroup>
+
+  <PropertyGroup Label="StrongName" Condition="Exists('$(MSBuildThisFileDirectory)kzu.snk')">
+    <!-- We use a single oss signing key for consumers that need strong-named assemblies -->
+    <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)kzu.snk</AssemblyOriginatorKeyFile>
+    <!-- These properties make it easier to add internals visible to other projects, even when signing is involved.
+         For example, you can simply add: 
+          <InternalsVisibleTo Include="MyProject.UnitTests" />
+
+         and the key will be appended automatically.
+    -->
+    <PublicKey>002400000480000094000000060200000024000052534131000400000100010051155fd0ee280be78d81cc979423f1129ec5dd28edce9cd94fd679890639cad54c121ebdb606f8659659cd313d3b3db7fa41e2271158dd602bb0039a142717117fa1f63d93a2d288a1c2f920ec05c4858d344a45d48ebd31c1368ab783596b382b611d8c92f9c1b3d338296aa21b12f3bc9f34de87756100c172c52a24bad2db</PublicKey>
+    <PublicKeyToken>00352124762f2aa5</PublicKeyToken>
+    <SignAssembly>true</SignAssembly>
   </PropertyGroup>
 
   <PropertyGroup Label="Version">

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -1,6 +1,10 @@
 <Project>
   <!-- To extend/change the defaults, create a Directory.targets alongside this file -->
 
+  <PropertyGroup Condition="'$(CI)' == 'true' and '$(Language)' == 'C#'">
+    <DefineConstants>CI;$(DefineConstants)</DefineConstants>
+  </PropertyGroup>
+  
   <PropertyGroup Condition="'$(IsPackable)' == ''">
     <!-- The Sdks\NuGet.Build.Tasks.Pack\build\NuGet.Build.Tasks.Pack.targets unconditionally sets 
         PackageId=AssemblyName if no PackageId is provided, and then defaults IsPackable=true if 
@@ -36,9 +40,8 @@
   <ItemGroup>
     <!-- Consider the project out of date if any of these files changes -->
     <UpToDateCheck Include="@(PackageFile);@(None);@(Content);@(EmbeddedResource)" />
-    <!-- We'll typically use ThisAssembly.Strings instead of the built-in resource manager codegen
-         The built-in one can be restored with: <EmbeddedResource Update="@(EmbeddedResource)" Generator="ResXFileCodeGenerator" -->
-    <EmbeddedResource Update="@(EmbeddedResource)"  Generator="" />
+    <!-- We'll typically use ThisAssembly.Strings instead of the built-in resource manager codegen -->
+    <EmbeddedResource Update="@(EmbeddedResource)"  Generator="" Condition="'$(EnableRexCodeGenerator)' != 'true'" />
   </ItemGroup>
 
   <Target Name="IsPackable" Returns="@(IsPackable)">


### PR DESCRIPTION
# devlooped/oss

- Checkout submodules recursively for dotnet-format step https://github.com/devlooped/oss/commit/4bc9de2
- Don't collect logs anymore https://github.com/devlooped/oss/commit/6bd81a3
- Don't run build when changing docs https://github.com/devlooped/oss/commit/db76fb9
- :hammer: Populate RepositoryBranch in CI w/MSBuild https://github.com/devlooped/oss/commit/55c0b32
- Don't fail the build if sleet finds no packages to push https://github.com/devlooped/oss/commit/6928fc7
- Automatically label dotnet-file bump and auto-delete branch https://github.com/devlooped/oss/commit/eeaeb55
- Allow manually running changelog and dotnet-file workflows https://github.com/devlooped/oss/commit/084aa7c
- Replace refs/tags too when considering version label https://github.com/devlooped/oss/commit/281b9b4
- Revert "Replace refs/tags too when considering version label" https://github.com/devlooped/oss/commit/7e15e3c
- Only set signing keyfile if it exists at default location https://github.com/devlooped/oss/commit/637662d
- Improve strong-naming properties defaults https://github.com/devlooped/oss/commit/c9924b5
- Use full name as Author, since Owner is already kzu https://github.com/devlooped/oss/commit/0fc6e0e
- Only include/pack icon.png if it exists in the default location https://github.com/devlooped/oss/commit/ae442c0
- Allow projects to preserve default EmbeddedResource item behavior https://github.com/devlooped/oss/commit/f19d5dd
- Add a CI constant for use in code to detect CI-built code https://github.com/devlooped/oss/commit/e7de4d0